### PR TITLE
chore: use git instead of local dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ darkpool-client = []
 renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", features = [
     "auth",
 ] }
-renegade-auth-api = { package = "auth-server-api", path = "/Users/joeykraut/work/relayer-extensions/auth/auth-server-api" }
+renegade-auth-api = { package = "auth-server-api", git = "https://github.com/renegade-fi/relayer-extensions.git" }
 renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git" }
 renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git" }
 renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git" }

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ use std::env;
 use std::sync::Arc;
 
 /// The quote mint for the atomic match
-const QUOTE_MINT: &str = "0xdf8d259c04020562717557f2b5a3cf28e92707d1"; // wETH on Arbitrum Sepolia
+const QUOTE_MINT: &str = "0xdf8d259c04020562717557f2b5a3cf28e92707d1"; // USDC on Arbitrum Sepolia
 /// The base mint for the atomic match
-const BASE_MINT: &str = "0xcf8a4dbdc5c23a599bf045784b3740b1722c86dd"; // USDC on Arbitrum Sepolia
+const BASE_MINT: &str = "0xcf8a4dbdc5c23a599bf045784b3740b1722c86dd"; // wETH on Arbitrum Sepolia
 /// The RPC URL for the Arbitrum Sepolia network
 const ARBITRUM_SEPOLIA_RPC: &str = "..."; // replace with your RPC URL
 


### PR DESCRIPTION
This PR fixes the `renegade-auth-api` dependency to use the git source