### PR TITLE
external-match-client: Add support for both base and quote amounts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ darkpool-client = []
 # === Renegade Dependencies === #
 renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", features = [
     "auth",
-] }
-renegade-auth-api = { package = "auth-server-api", git = "https://github.com/renegade-fi/relayer-extensions.git" }
-renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git" }
-renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git" }
-renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git" }
-renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git" }
-renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git" }
+], rev = "bd09457" }
+renegade-auth-api = { package = "auth-server-api", git = "https://github.com/renegade-fi/relayer-extensions.git", rev = "d3aa518" }
+renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git", rev = "bd09457" }
+renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git", rev = "bd09457" }
+renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git", rev = "bd09457" }
+renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git", rev = "bd09457" }
+renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", rev = "bd09457" }
 
 # === Http === #
 reqwest = { version = "0.11", features = ["json"] }


### PR DESCRIPTION
### Purpose
This PR updates the SDK to support both base and quote amounts in an `ExternalOrder` specification.

### Testing
- [x] Testing with a local client now.