### PR TITLE
external-match-client: Allow order updates in quote assembly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ path = "examples/quote_validation/quote_validation.rs"
 name = "non_sender_receiver"
 path = "examples/external_match/non_sender_receiver.rs"
 
+[[example]]
+name = "modify_order_after_quote"
+path = "examples/external_match/modify_order_after_quote.rs"
+
 [features]
 default = ["external-match-client", "darkpool-client"]
 external-match-client = []
@@ -24,13 +28,13 @@ darkpool-client = []
 # === Renegade Dependencies === #
 renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", features = [
     "auth",
-], rev = "6309588" }
+], rev = "31129bc" }
 renegade-auth-api = { package = "auth-server-api", git = "https://github.com/renegade-fi/relayer-extensions.git", rev = "d3aa518" }
-renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git", rev = "6309588" }
-renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git", rev = "6309588" }
-renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git", rev = "6309588" }
-renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git", rev = "6309588" }
-renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", rev = "6309588" }
+renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git", rev = "31129bc" }
+renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git", rev = "31129bc" }
+renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git", rev = "31129bc" }
+renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git", rev = "31129bc" }
+renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", rev = "31129bc" }
 
 # === Http === #
 reqwest = { version = "0.11", features = ["json"] }

--- a/examples/external_match/modify_order_after_quote.rs
+++ b/examples/external_match/modify_order_after_quote.rs
@@ -1,0 +1,98 @@
+//! An example in which we tweak an order before assembling the quote
+
+use std::{str::FromStr, sync::Arc};
+
+use ethers::middleware::Middleware;
+use ethers::prelude::*;
+use renegade_sdk::{
+    types::{AtomicMatchApiBundle, ExternalOrder, OrderSide},
+    AssembleQuoteOptions, ExternalMatchClient, ExternalOrderBuilder,
+};
+
+/// The RPC URL to use
+const RPC_URL: &str = env!("RPC_URL");
+
+/// Testnet wETH
+const BASE_MINT: &str = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a";
+/// Testnet USDC
+const QUOTE_MINT: &str = "0xdf8d259c04020562717557f2b5a3cf28e92707d1";
+
+/// The middleware type
+type Wallet = Arc<SignerMiddleware<Provider<Http>, LocalWallet>>;
+
+#[tokio::main]
+async fn main() -> Result<(), eyre::Error> {
+    // Get wallet from private key
+    let signer = get_signer().await?;
+
+    // Get the external match client
+    let api_key = std::env::var("EXTERNAL_MATCH_KEY").unwrap();
+    let api_secret = std::env::var("EXTERNAL_MATCH_SECRET").unwrap();
+    let client = ExternalMatchClient::new_sepolia_client(&api_key, &api_secret).unwrap();
+
+    let order = ExternalOrderBuilder::new()
+        .base_mint(BASE_MINT)
+        .quote_mint(QUOTE_MINT)
+        .quote_amount(30_000_000) // $30 USDC
+        .min_fill_size(30_000_000) // $30 USDC
+        .side(OrderSide::Sell)
+        .build()
+        .unwrap();
+
+    fetch_quote_and_execute(&client, order, &signer).await?;
+    Ok(())
+}
+
+/// Fetch a quote from the external api and print it
+async fn fetch_quote_and_execute(
+    client: &ExternalMatchClient,
+    order: ExternalOrder,
+    wallet: &Wallet,
+) -> Result<(), eyre::Error> {
+    // Fetch a quote from the relayer
+    println!("Fetching quote...");
+    let res = client.request_quote(order.clone()).await?;
+    let quote = match res {
+        Some(quote) => quote,
+        None => eyre::bail!("No quote found"),
+    };
+
+    // We only want to sell $29 of WETH, not $30
+    let mut updated_order = order.clone();
+    updated_order.quote_amount = 29_000_000;
+    updated_order.min_fill_size = 29_000_000;
+
+    // Assemble the quote into a bundle
+    println!("Assembling quote...");
+    let options = AssembleQuoteOptions::default().with_updated_order(updated_order);
+    let bundle = match client.assemble_quote_with_options(quote, options).await? {
+        Some(bundle) => bundle,
+        None => eyre::bail!("No bundle found"),
+    };
+    execute_bundle(wallet, bundle).await
+}
+
+/// Execute a bundle directly
+async fn execute_bundle(wallet: &Wallet, bundle: AtomicMatchApiBundle) -> Result<(), eyre::Error> {
+    println!("Submitting bundle...\n");
+    let tx = bundle.settlement_tx.clone();
+    let receipt: PendingTransaction<_> = wallet.send_transaction(tx, None).await.unwrap();
+
+    println!("Successfully submitted transaction: {:#x}", receipt.tx_hash());
+    Ok(())
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Get a wallet from a private key environment variable
+async fn get_signer() -> Result<Wallet, eyre::Error> {
+    let provider = Provider::<Http>::try_from(RPC_URL).unwrap();
+    let chain_id = provider.get_chainid().await.unwrap().as_u64();
+    let pkey = std::env::var("PKEY").unwrap();
+    let wallet = LocalWallet::from_str(&pkey).unwrap().with_chain_id(chain_id);
+    let middleware = Arc::new(SignerMiddleware::new(provider, wallet));
+
+    Ok(middleware)
+}

--- a/src/external_match_client/mod.rs
+++ b/src/external_match_client/mod.rs
@@ -5,7 +5,7 @@
 //! state committed into the Renegade darkpool.
 
 mod client;
-pub use client::{ExternalMatchClient, ExternalMatchOptions};
+pub use client::{AssembleQuoteOptions, ExternalMatchClient, ExternalMatchOptions};
 
 mod error;
 pub use error::ExternalMatchClientError;


### PR DESCRIPTION
### Purpose
This PR allows order updates in between quote and assembly in the rust SDK. The `base_amount`, `quote_amount`, and `min_fill_size` fields are all allowed to change.

I also added an example [`examples/modify_order_after_quote`](./examples/modify_order_after_quote.rs) which demonstrates this.

### Testing
- [x] Ran example against testnet