### PR TITLE
external-match-client: Add options for gas sponsorship

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ ethers = "2.0.0"
 eyre = "0.6.10"
 num-bigint = "0.4.3"
 thiserror = "1.0.31"
+url = "2.5.0"
 
 # === Example Dependencies === #
 [dev-dependencies]

--- a/src/external_match_client/client.rs
+++ b/src/external_match_client/client.rs
@@ -12,10 +12,13 @@ use reqwest::{
     header::{HeaderMap, HeaderValue},
     StatusCode,
 };
+use url::form_urlencoded;
 
 use crate::http::RelayerHttpClient;
 
-use super::error::ExternalMatchClientError;
+use super::{
+    error::ExternalMatchClientError, GAS_REFUND_ADDRESS_QUERY_PARAM, GAS_SPONSORSHIP_QUERY_PARAM,
+};
 
 /// The sepolia base URL
 const SEPOLIA_BASE_URL: &str = "https://testnet.auth-server.renegade.fi";
@@ -23,32 +26,29 @@ const SEPOLIA_BASE_URL: &str = "https://testnet.auth-server.renegade.fi";
 const MAINNET_BASE_URL: &str = "https://mainnet.auth-server.renegade.fi";
 
 /// The options for requesting an external match
+#[deprecated(
+    since = "0.1.0",
+    note = "This endpoint will soon be removed, use `request_quote` and `assemble_quote` instead"
+)]
 #[derive(Clone, Default)]
 pub struct ExternalMatchOptions {
     /// Whether to perform gas estimation
     pub do_gas_estimation: bool,
+    /// Whether or not to request gas sponsorship for the match
+    ///
+    /// If granted, the auth server will sign the bundle to indicate that the
+    /// gas paid to settle the match should be refunded to the given address
+    /// (`tx.origin` if not specified). This is subject to a rate limit.
+    pub sponsor_gas: bool,
+    /// The address to refund gas to if `sponsor_gas` is true
+    pub gas_refund_address: Option<String>,
     /// The receiver address that the darkpool will send funds to
     ///
     /// If not provided, the receiver address is the message sender
     pub receiver_address: Option<String>,
 }
 
-/// The options for assembling a quote
-#[derive(Clone, Default)]
-pub struct AssembleQuoteOptions {
-    /// Whether to do gas estimation
-    pub do_gas_estimation: bool,
-    /// The receiver address that the darkpool will send funds to
-    ///
-    /// If not provided, the receiver address is the message sender
-    pub receiver_address: Option<String>,
-    /// The updated order to use when assembling the quote
-    ///
-    /// The `base_amount`, `quote_amount`, and `min_fill_size` are allowed to
-    /// change, but the pair and side is not
-    pub updated_order: Option<ExternalOrder>,
-}
-
+#[allow(deprecated)]
 impl ExternalMatchOptions {
     /// Create a new options with default values
     pub fn new() -> Self {
@@ -66,6 +66,55 @@ impl ExternalMatchOptions {
         self.receiver_address = Some(receiver_address);
         self
     }
+
+    /// Request gas sponsorship
+    pub fn request_gas_sponsorship(mut self) -> Self {
+        self.sponsor_gas = true;
+        self
+    }
+
+    /// Set the gas refund address
+    pub fn with_gas_refund_address(mut self, gas_refund_address: String) -> Self {
+        self.gas_refund_address = Some(gas_refund_address);
+        self
+    }
+
+    /// Get the request path given the options
+    pub(crate) fn build_request_path(&self) -> String {
+        let mut query = form_urlencoded::Serializer::new(String::new());
+
+        // Add query params for gas sponsorship
+        query.append_pair(GAS_SPONSORSHIP_QUERY_PARAM, &self.sponsor_gas.to_string());
+        if let Some(addr) = &self.gas_refund_address {
+            query.append_pair(GAS_REFUND_ADDRESS_QUERY_PARAM, addr);
+        }
+
+        format!("{}?{}", REQUEST_EXTERNAL_MATCH_ROUTE, query.finish())
+    }
+}
+
+/// The options for assembling a quote
+#[derive(Clone, Default)]
+pub struct AssembleQuoteOptions {
+    /// Whether to do gas estimation
+    pub do_gas_estimation: bool,
+    /// Whether or not to request gas sponsorship for the match
+    ///
+    /// If granted, the auth server will sign the bundle to indicate that the
+    /// gas paid to settle the match should be refunded to the given address
+    /// (`tx.origin` if not specified). This is subject to a rate limit.
+    pub sponsor_gas: bool,
+    /// The address to refund gas to if `sponsor_gas` is true
+    pub gas_refund_address: Option<String>,
+    /// The receiver address that the darkpool will send funds to
+    ///
+    /// If not provided, the receiver address is the message sender
+    pub receiver_address: Option<String>,
+    /// The updated order to use when assembling the quote
+    ///
+    /// The `base_amount`, `quote_amount`, and `min_fill_size` are allowed to
+    /// change, but the pair and side is not
+    pub updated_order: Option<ExternalOrder>,
 }
 
 impl AssembleQuoteOptions {
@@ -80,6 +129,18 @@ impl AssembleQuoteOptions {
         self
     }
 
+    /// Request gas sponsorship
+    pub fn request_gas_sponsorship(mut self) -> Self {
+        self.sponsor_gas = true;
+        self
+    }
+
+    /// Set the gas refund address
+    pub fn with_gas_refund_address(mut self, gas_refund_address: String) -> Self {
+        self.gas_refund_address = Some(gas_refund_address);
+        self
+    }
+
     /// Set the receiver address
     pub fn with_receiver_address(mut self, receiver_address: String) -> Self {
         self.receiver_address = Some(receiver_address);
@@ -90,6 +151,18 @@ impl AssembleQuoteOptions {
     pub fn with_updated_order(mut self, updated_order: ExternalOrder) -> Self {
         self.updated_order = Some(updated_order);
         self
+    }
+
+    /// Get the request path given the options
+    pub(crate) fn build_request_path(&self) -> String {
+        let mut query = form_urlencoded::Serializer::new(String::new());
+        query.append_pair(GAS_SPONSORSHIP_QUERY_PARAM, &self.sponsor_gas.to_string());
+
+        if let Some(addr) = &self.gas_refund_address {
+            query.append_pair(GAS_REFUND_ADDRESS_QUERY_PARAM, addr);
+        }
+
+        format!("{}?{}", ASSEMBLE_EXTERNAL_MATCH_ROUTE, query.finish())
     }
 }
 
@@ -162,21 +235,26 @@ impl ExternalMatchClient {
         quote: SignedExternalQuote,
         options: AssembleQuoteOptions,
     ) -> Result<Option<AtomicMatchApiBundle>, ExternalMatchClientError> {
+        let path = options.build_request_path();
         let request = AssembleExternalMatchRequest {
             signed_quote: quote,
             receiver_address: options.receiver_address,
             do_gas_estimation: options.do_gas_estimation,
             updated_order: options.updated_order,
         };
-        let path = ASSEMBLE_EXTERNAL_MATCH_ROUTE;
         let headers = self.get_headers()?;
 
-        let resp = self.http_client.post_with_headers_raw(path, request, headers).await?;
+        let resp = self.http_client.post_with_headers_raw(path.as_str(), request, headers).await?;
         let match_resp = Self::handle_optional_response::<ExternalMatchResponse>(resp).await?;
         Ok(match_resp.map(|r| r.match_bundle))
     }
 
     /// Request an external match
+    #[deprecated(
+        since = "0.1.0",
+        note = "This endpoint will soon be removed, use `request_quote` and `assemble_quote` instead"
+    )]
+    #[allow(deprecated)]
     pub async fn request_external_match(
         &self,
         order: ExternalOrder,
@@ -185,21 +263,26 @@ impl ExternalMatchClient {
     }
 
     /// Request an external match and specify any options for the request
+    #[deprecated(
+        since = "0.1.0",
+        note = "This endpoint will soon be removed, use `request_quote` and `assemble_quote` instead"
+    )]
+    #[allow(deprecated)]
     pub async fn request_external_match_with_options(
         &self,
         order: ExternalOrder,
         options: ExternalMatchOptions,
     ) -> Result<Option<AtomicMatchApiBundle>, ExternalMatchClientError> {
+        let path = options.build_request_path();
         let do_gas_estimation = options.do_gas_estimation;
         let request = ExternalMatchRequest {
             external_order: order,
             do_gas_estimation,
             receiver_address: options.receiver_address,
         };
-        let path = REQUEST_EXTERNAL_MATCH_ROUTE;
         let headers = self.get_headers()?;
 
-        let resp = self.http_client.post_with_headers_raw(path, request, headers).await?;
+        let resp = self.http_client.post_with_headers_raw(path.as_str(), request, headers).await?;
         let match_resp = Self::handle_optional_response::<ExternalMatchResponse>(resp).await?;
         Ok(match_resp.map(|r| r.match_bundle))
     }

--- a/src/external_match_client/mod.rs
+++ b/src/external_match_client/mod.rs
@@ -5,6 +5,7 @@
 //! state committed into the Renegade darkpool.
 
 mod client;
+#[allow(deprecated)]
 pub use client::{AssembleQuoteOptions, ExternalMatchClient, ExternalMatchOptions};
 
 mod error;
@@ -13,6 +14,11 @@ use num_bigint::BigUint;
 use renegade_api::http::external_match::ExternalOrder;
 use renegade_circuit_types::{order::OrderSide, Amount};
 use renegade_util::hex::biguint_from_hex_string;
+
+/// The auth server query param for requesting gas sponsorship
+pub const GAS_SPONSORSHIP_QUERY_PARAM: &str = "use_gas_sponsorship";
+/// The auth server query param for the gas refund address
+pub const GAS_REFUND_ADDRESS_QUERY_PARAM: &str = "refund_address";
 
 /// A builder for an [`ExternalOrder`]
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
### Purpose
This PR adds gas sponsorship options to direct match and quote assembly options.

### Testing
- [x] All examples run and pass
- [ ] Test with a new example for sponsorship