### PR TITLE
external-match-client: Add supported tokens method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ path = "examples/external_match/modify_order_after_quote.rs"
 name = "gas_sponsorship"
 path = "examples/external_match/gas_sponsorship.rs"
 
+[[example]]
+name = "supported_tokens"
+path = "examples/external_match/supported_tokens.rs"
+
 [features]
 default = ["external-match-client", "darkpool-client"]
 external-match-client = []
@@ -33,15 +37,15 @@ darkpool-client = []
 renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", default-features = false, features = [
     "auth",
     "external-match-api",
-], rev = "2e62168a" }
+], rev = "428b64d9" }
 renegade-auth-api = { package = "auth-server-api", git = "https://github.com/renegade-fi/relayer-extensions.git", rev = "d3aa518" }
-renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git", rev = "2e62168a", default-features = false }
-renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git", rev = "2e62168a", default-features = false, feature = [
+renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git", rev = "428b64d9", default-features = false }
+renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git", rev = "428b64d9", default-features = false, feature = [
     "hmac",
 ] }
-renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git", rev = "2e62168a", default-features = false }
-renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git", rev = "2e62168a" }
-renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", rev = "2e62168a" }
+renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git", rev = "428b64d9", default-features = false }
+renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git", rev = "428b64d9" }
+renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", rev = "428b64d9" }
 
 # === Http === #
 reqwest = { version = "0.11", features = ["json"] }

--- a/examples/external_match/supported_tokens.rs
+++ b/examples/external_match/supported_tokens.rs
@@ -1,0 +1,26 @@
+//! An example showing how to fetch supported tokens and find specific token
+//! addresses
+
+use renegade_sdk::ExternalMatchClient;
+
+#[tokio::main]
+async fn main() -> Result<(), eyre::Error> {
+    // Get the external match client
+    let api_key = std::env::var("EXTERNAL_MATCH_KEY").unwrap();
+    let api_secret = std::env::var("EXTERNAL_MATCH_SECRET").unwrap();
+    let client = ExternalMatchClient::new_sepolia_client(&api_key, &api_secret).unwrap();
+
+    // Fetch supported tokens
+    println!("Fetching supported tokens...");
+    let tokens = client.get_supported_tokens().await?;
+
+    // Find and print WETH details
+    for token in tokens.tokens {
+        if token.symbol.to_uppercase() == "WETH" {
+            println!("\nFound WETH!");
+            println!("Address: {}", token.address);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Purpose
This PR adds a supported tokens method and example for fetching the token address of WETH

### Testing
- [x] All examples pass