### PR TITLE
external-match-client: api-types: Add `gas_sponsored` flag

### DIFF
--- a/examples/external_match/external_match.rs
+++ b/examples/external_match/external_match.rs
@@ -57,11 +57,11 @@ async fn fetch_quote_and_execute(
 
     // Assemble the quote into a bundle
     println!("Assembling quote...");
-    let bundle = match client.assemble_quote(quote).await? {
-        Some(bundle) => bundle,
+    let resp = match client.assemble_quote(quote).await? {
+        Some(resp) => resp,
         None => eyre::bail!("No bundle found"),
     };
-    execute_bundle(wallet, bundle).await
+    execute_bundle(wallet, resp.match_bundle).await
 }
 
 /// Execute a bundle directly

--- a/examples/external_match/gas_sponsorship.rs
+++ b/examples/external_match/gas_sponsorship.rs
@@ -65,11 +65,15 @@ async fn fetch_quote_and_execute(
         .request_gas_sponsorship() // Enable gas sponsorship
         .with_gas_refund_address(GAS_REFUND_ADDRESS.to_string()); // Set the refund address
 
-    let bundle = match client.assemble_quote_with_options(quote, options).await? {
+    let resp = match client.assemble_quote_with_options(quote, options).await? {
         Some(bundle) => bundle,
         None => eyre::bail!("No bundle found"),
     };
-    execute_bundle(wallet, bundle).await
+
+    if !resp.gas_sponsored {
+        eyre::bail!("Bundle was not sponsored");
+    }
+    execute_bundle(wallet, resp.match_bundle).await
 }
 
 /// Execute a bundle directly

--- a/examples/external_match/modify_order_after_quote.rs
+++ b/examples/external_match/modify_order_after_quote.rs
@@ -65,11 +65,11 @@ async fn fetch_quote_and_execute(
     // Assemble the quote into a bundle
     println!("Assembling quote...");
     let options = AssembleQuoteOptions::default().with_updated_order(updated_order);
-    let bundle = match client.assemble_quote_with_options(quote, options).await? {
-        Some(bundle) => bundle,
+    let resp = match client.assemble_quote_with_options(quote, options).await? {
+        Some(resp) => resp,
         None => eyre::bail!("No bundle found"),
     };
-    execute_bundle(wallet, bundle).await
+    execute_bundle(wallet, resp.match_bundle).await
 }
 
 /// Execute a bundle directly

--- a/examples/external_match/non_sender_receiver.rs
+++ b/examples/external_match/non_sender_receiver.rs
@@ -63,11 +63,11 @@ async fn fetch_quote_and_execute(
     // Assemble the quote into a bundle
     println!("Assembling quote...");
     let options = AssembleQuoteOptions::new().with_receiver_address(RECEIVER_ADDRESS.to_string());
-    let bundle = match client.assemble_quote_with_options(quote, options).await? {
-        Some(bundle) => bundle,
+    let resp = match client.assemble_quote_with_options(quote, options).await? {
+        Some(resp) => resp,
         None => eyre::bail!("No bundle found"),
     };
-    execute_bundle(wallet, bundle).await
+    execute_bundle(wallet, resp.match_bundle).await
 }
 
 /// Execute a bundle directly

--- a/examples/external_match/quote_validation.rs
+++ b/examples/external_match/quote_validation.rs
@@ -59,11 +59,11 @@ async fn fetch_quote_and_execute(
 
     // Assemble the quote into a bundle
     println!("Assembling quote...");
-    let bundle = match client.assemble_quote(signed_quote).await? {
-        Some(bundle) => bundle,
+    let resp = match client.assemble_quote(signed_quote).await? {
+        Some(resp) => resp,
         None => eyre::bail!("No bundle found"),
     };
-    execute_bundle(wallet, bundle).await
+    execute_bundle(wallet, resp.match_bundle).await
 }
 
 /// Validate a quote

--- a/src/external_match_client/api_types.rs
+++ b/src/external_match_client/api_types.rs
@@ -1,0 +1,17 @@
+//! Types for the external match client
+
+use renegade_api::http::external_match::AtomicMatchApiBundle;
+use serde::{Deserialize, Serialize};
+
+/// The response type for requesting an external match
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalMatchResponse {
+    /// The raw response from the relayer
+    pub match_bundle: AtomicMatchApiBundle,
+    /// Whether the match has received gas sponsorship
+    ///
+    /// If `true`, the bundle is routed through a gas rebate contract that
+    /// refunds the gas used by the match to the configured address
+    #[serde(rename = "is_sponsored", default)]
+    pub gas_sponsored: bool,
+}

--- a/src/external_match_client/client.rs
+++ b/src/external_match_client/client.rs
@@ -2,10 +2,9 @@
 
 use renegade_api::http::{
     external_match::{
-        AssembleExternalMatchRequest, AtomicMatchApiBundle, ExternalMatchRequest,
-        ExternalMatchResponse, ExternalOrder, ExternalQuoteRequest, ExternalQuoteResponse,
-        SignedExternalQuote, ASSEMBLE_EXTERNAL_MATCH_ROUTE, REQUEST_EXTERNAL_MATCH_ROUTE,
-        REQUEST_EXTERNAL_QUOTE_ROUTE,
+        AssembleExternalMatchRequest, ExternalMatchRequest, ExternalOrder, ExternalQuoteRequest,
+        ExternalQuoteResponse, SignedExternalQuote, ASSEMBLE_EXTERNAL_MATCH_ROUTE,
+        REQUEST_EXTERNAL_MATCH_ROUTE, REQUEST_EXTERNAL_QUOTE_ROUTE,
     },
     GetSupportedTokensResponse, GET_SUPPORTED_TOKENS_ROUTE,
 };
@@ -20,7 +19,8 @@ use url::form_urlencoded;
 use crate::http::RelayerHttpClient;
 
 use super::{
-    error::ExternalMatchClientError, GAS_REFUND_ADDRESS_QUERY_PARAM, GAS_SPONSORSHIP_QUERY_PARAM,
+    api_types::ExternalMatchResponse, error::ExternalMatchClientError,
+    GAS_REFUND_ADDRESS_QUERY_PARAM, GAS_SPONSORSHIP_QUERY_PARAM,
 };
 
 // -------------
@@ -260,7 +260,7 @@ impl ExternalMatchClient {
     pub async fn assemble_quote(
         &self,
         quote: SignedExternalQuote,
-    ) -> Result<Option<AtomicMatchApiBundle>, ExternalMatchClientError> {
+    ) -> Result<Option<ExternalMatchResponse>, ExternalMatchClientError> {
         self.assemble_quote_with_options(quote, AssembleQuoteOptions::default()).await
     }
 
@@ -269,7 +269,7 @@ impl ExternalMatchClient {
         &self,
         quote: SignedExternalQuote,
         options: AssembleQuoteOptions,
-    ) -> Result<Option<AtomicMatchApiBundle>, ExternalMatchClientError> {
+    ) -> Result<Option<ExternalMatchResponse>, ExternalMatchClientError> {
         let path = options.build_request_path();
         let request = AssembleExternalMatchRequest {
             signed_quote: quote,
@@ -282,7 +282,7 @@ impl ExternalMatchClient {
         let resp =
             self.auth_http_client.post_with_headers_raw(path.as_str(), request, headers).await?;
         let match_resp = Self::handle_optional_response::<ExternalMatchResponse>(resp).await?;
-        Ok(match_resp.map(|r| r.match_bundle))
+        Ok(match_resp)
     }
 
     /// Request an external match
@@ -294,7 +294,7 @@ impl ExternalMatchClient {
     pub async fn request_external_match(
         &self,
         order: ExternalOrder,
-    ) -> Result<Option<AtomicMatchApiBundle>, ExternalMatchClientError> {
+    ) -> Result<Option<ExternalMatchResponse>, ExternalMatchClientError> {
         self.request_external_match_with_options(order, Default::default()).await
     }
 
@@ -308,7 +308,7 @@ impl ExternalMatchClient {
         &self,
         order: ExternalOrder,
         options: ExternalMatchOptions,
-    ) -> Result<Option<AtomicMatchApiBundle>, ExternalMatchClientError> {
+    ) -> Result<Option<ExternalMatchResponse>, ExternalMatchClientError> {
         let path = options.build_request_path();
         let do_gas_estimation = options.do_gas_estimation;
         let request = ExternalMatchRequest {
@@ -321,7 +321,7 @@ impl ExternalMatchClient {
         let resp =
             self.auth_http_client.post_with_headers_raw(path.as_str(), request, headers).await?;
         let match_resp = Self::handle_optional_response::<ExternalMatchResponse>(resp).await?;
-        Ok(match_resp.map(|r| r.match_bundle))
+        Ok(match_resp)
     }
 
     /// Helper function to handle response that might be NO_CONTENT, OK with

--- a/src/external_match_client/mod.rs
+++ b/src/external_match_client/mod.rs
@@ -4,6 +4,8 @@
 //! committed into the Renegade darkpool, and an external party -- one with no
 //! state committed into the Renegade darkpool.
 
+pub mod api_types;
+
 mod client;
 #[allow(deprecated)]
 pub use client::{AssembleQuoteOptions, ExternalMatchClient, ExternalMatchOptions};


### PR DESCRIPTION
### Purpose
This PR adds the `gas_sponsored` flag to the response received by the client for assembling quotes.

### Testing
- [x] Tested the gas sponsorship example