### PR TITLE
external-match-client: Internalize API types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,46 +6,43 @@ edition = "2021"
 [[example]]
 name = "external_match"
 path = "examples/external_match/external_match.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "quote_validation"
 path = "examples/external_match/quote_validation.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "non_sender_receiver"
 path = "examples/external_match/non_sender_receiver.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "modify_order_after_quote"
 path = "examples/external_match/modify_order_after_quote.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "gas_sponsorship"
 path = "examples/external_match/gas_sponsorship.rs"
+required-features = ["examples"]
 
 [[example]]
 name = "supported_tokens"
 path = "examples/external_match/supported_tokens.rs"
+required-features = ["examples"]
 
 [features]
 default = ["external-match-client", "darkpool-client"]
 external-match-client = []
 darkpool-client = []
+examples = ["dep:alloy"]
 
 [dependencies]
-# === Renegade Dependencies === #
-renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", default-features = false, features = [
-    "auth",
-    "external-match-api",
-], rev = "428b64d9" }
-renegade-auth-api = { package = "auth-server-api", git = "https://github.com/renegade-fi/relayer-extensions.git", rev = "d3aa518" }
-renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git", rev = "428b64d9", default-features = false }
-renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git", rev = "428b64d9", default-features = false, feature = [
-    "hmac",
-] }
-renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git", rev = "428b64d9", default-features = false }
-renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git", rev = "428b64d9" }
-renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", rev = "428b64d9" }
+# === Auth === #
+hmac = "0.12"
+sha2 = { version = "0.10", features = ["asm"] }
 
 # === Http === #
 reqwest = { version = "0.11", features = ["json"] }
@@ -53,9 +50,11 @@ serde = { version = "^1.0.197" }
 serde_json = "1.0.64"
 
 # === Ethereum === #
-ethers = "2.0.0"
+alloy = { version = "0.12", features = ["essentials"], optional = true }
+alloy-rpc-types-eth = "0.12"
 
 # === Misc === #
+base64 = "0.22"
 eyre = "0.6.10"
 num-bigint = "0.4.3"
 thiserror = "1.0.31"

--- a/examples/external_match/external_match.rs
+++ b/examples/external_match/external_match.rs
@@ -1,22 +1,13 @@
-use std::{str::FromStr, sync::Arc};
-
-use ethers::middleware::Middleware;
-use ethers::prelude::*;
+use renegade_sdk::example_utils::{build_renegade_client, execute_bundle, get_signer, Wallet};
 use renegade_sdk::{
-    types::{AtomicMatchApiBundle, ExternalOrder, OrderSide},
+    types::{ExternalOrder, OrderSide},
     ExternalMatchClient, ExternalOrderBuilder,
 };
-
-/// The RPC URL to use
-const RPC_URL: &str = env!("RPC_URL");
 
 /// Testnet wETH
 const BASE_MINT: &str = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a";
 /// Testnet USDC
 const QUOTE_MINT: &str = "0xdf8d259c04020562717557f2b5a3cf28e92707d1";
-
-/// The middleware type
-type Wallet = Arc<SignerMiddleware<Provider<Http>, LocalWallet>>;
 
 #[tokio::main]
 async fn main() -> Result<(), eyre::Error> {
@@ -24,10 +15,7 @@ async fn main() -> Result<(), eyre::Error> {
     let signer = get_signer().await?;
 
     // Get the external match client
-    let api_key = std::env::var("EXTERNAL_MATCH_KEY").unwrap();
-    let api_secret = std::env::var("EXTERNAL_MATCH_SECRET").unwrap();
-    let client = ExternalMatchClient::new_sepolia_client(&api_key, &api_secret).unwrap();
-
+    let client = build_renegade_client()?;
     let order = ExternalOrderBuilder::new()
         .base_mint(BASE_MINT)
         .quote_mint(QUOTE_MINT)
@@ -62,29 +50,4 @@ async fn fetch_quote_and_execute(
         None => eyre::bail!("No bundle found"),
     };
     execute_bundle(wallet, resp.match_bundle).await
-}
-
-/// Execute a bundle directly
-async fn execute_bundle(wallet: &Wallet, bundle: AtomicMatchApiBundle) -> Result<(), eyre::Error> {
-    println!("Submitting bundle...\n");
-    let tx = bundle.settlement_tx.clone();
-    let receipt: PendingTransaction<_> = wallet.send_transaction(tx, None).await.unwrap();
-
-    println!("Successfully submitted transaction: {:#x}", receipt.tx_hash());
-    Ok(())
-}
-
-// -----------
-// | Helpers |
-// -----------
-
-/// Get a wallet from a private key environment variable
-async fn get_signer() -> Result<Wallet, eyre::Error> {
-    let provider = Provider::<Http>::try_from(RPC_URL).unwrap();
-    let chain_id = provider.get_chainid().await.unwrap().as_u64();
-    let pkey = std::env::var("PKEY").unwrap();
-    let wallet = LocalWallet::from_str(&pkey).unwrap().with_chain_id(chain_id);
-    let middleware = Arc::new(SignerMiddleware::new(provider, wallet));
-
-    Ok(middleware)
 }

--- a/examples/external_match/gas_sponsorship.rs
+++ b/examples/external_match/gas_sponsorship.rs
@@ -1,16 +1,10 @@
 //! An example requesting an external match with gas sponsorship
 
-use std::{str::FromStr, sync::Arc};
-
-use ethers::middleware::Middleware;
-use ethers::prelude::*;
 use renegade_sdk::{
-    types::{AtomicMatchApiBundle, ExternalOrder, OrderSide},
+    example_utils::{build_renegade_client, execute_bundle, get_signer, Wallet},
+    types::{ExternalOrder, OrderSide},
     AssembleQuoteOptions, ExternalMatchClient, ExternalOrderBuilder,
 };
-
-/// The RPC URL to use
-const RPC_URL: &str = env!("RPC_URL");
 
 /// Testnet wETH
 const BASE_MINT: &str = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a";
@@ -19,19 +13,13 @@ const QUOTE_MINT: &str = "0xdf8d259c04020562717557f2b5a3cf28e92707d1";
 /// The gas refund address: the address that will receive the gas refund
 const GAS_REFUND_ADDRESS: &str = "0x99D9133afE1B9eC1726C077cA2b79Dcbb5969707";
 
-/// The middleware type
-type Wallet = Arc<SignerMiddleware<Provider<Http>, LocalWallet>>;
-
 #[tokio::main]
 async fn main() -> Result<(), eyre::Error> {
     // Get wallet from private key
     let signer = get_signer().await?;
 
     // Get the external match client
-    let api_key = std::env::var("EXTERNAL_MATCH_KEY").unwrap();
-    let api_secret = std::env::var("EXTERNAL_MATCH_SECRET").unwrap();
-    let client = ExternalMatchClient::new_sepolia_client(&api_key, &api_secret).unwrap();
-
+    let client = build_renegade_client()?;
     let order = ExternalOrderBuilder::new()
         .base_mint(BASE_MINT)
         .quote_mint(QUOTE_MINT)
@@ -74,29 +62,4 @@ async fn fetch_quote_and_execute(
         eyre::bail!("Bundle was not sponsored");
     }
     execute_bundle(wallet, resp.match_bundle).await
-}
-
-/// Execute a bundle directly
-async fn execute_bundle(wallet: &Wallet, bundle: AtomicMatchApiBundle) -> Result<(), eyre::Error> {
-    println!("Submitting bundle...\n");
-    let tx = bundle.settlement_tx.clone();
-    let receipt: PendingTransaction<_> = wallet.send_transaction(tx, None).await.unwrap();
-
-    println!("Successfully submitted transaction: {:#x}", receipt.tx_hash());
-    Ok(())
-}
-
-// -----------
-// | Helpers |
-// -----------
-
-/// Get a wallet from a private key environment variable
-async fn get_signer() -> Result<Wallet, eyre::Error> {
-    let provider = Provider::<Http>::try_from(RPC_URL).unwrap();
-    let chain_id = provider.get_chainid().await.unwrap().as_u64();
-    let pkey = std::env::var("PKEY").unwrap();
-    let wallet = LocalWallet::from_str(&pkey).unwrap().with_chain_id(chain_id);
-    let middleware = Arc::new(SignerMiddleware::new(provider, wallet));
-
-    Ok(middleware)
 }

--- a/examples/external_match/modify_order_after_quote.rs
+++ b/examples/external_match/modify_order_after_quote.rs
@@ -1,24 +1,15 @@
 //! An example in which we tweak an order before assembling the quote
 
-use std::{str::FromStr, sync::Arc};
-
-use ethers::middleware::Middleware;
-use ethers::prelude::*;
 use renegade_sdk::{
-    types::{AtomicMatchApiBundle, ExternalOrder, OrderSide},
+    example_utils::{build_renegade_client, execute_bundle, get_signer, Wallet},
+    types::{ExternalOrder, OrderSide},
     AssembleQuoteOptions, ExternalMatchClient, ExternalOrderBuilder,
 };
-
-/// The RPC URL to use
-const RPC_URL: &str = env!("RPC_URL");
 
 /// Testnet wETH
 const BASE_MINT: &str = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a";
 /// Testnet USDC
 const QUOTE_MINT: &str = "0xdf8d259c04020562717557f2b5a3cf28e92707d1";
-
-/// The middleware type
-type Wallet = Arc<SignerMiddleware<Provider<Http>, LocalWallet>>;
 
 #[tokio::main]
 async fn main() -> Result<(), eyre::Error> {
@@ -26,10 +17,7 @@ async fn main() -> Result<(), eyre::Error> {
     let signer = get_signer().await?;
 
     // Get the external match client
-    let api_key = std::env::var("EXTERNAL_MATCH_KEY").unwrap();
-    let api_secret = std::env::var("EXTERNAL_MATCH_SECRET").unwrap();
-    let client = ExternalMatchClient::new_sepolia_client(&api_key, &api_secret).unwrap();
-
+    let client = build_renegade_client()?;
     let order = ExternalOrderBuilder::new()
         .base_mint(BASE_MINT)
         .quote_mint(QUOTE_MINT)
@@ -70,29 +58,4 @@ async fn fetch_quote_and_execute(
         None => eyre::bail!("No bundle found"),
     };
     execute_bundle(wallet, resp.match_bundle).await
-}
-
-/// Execute a bundle directly
-async fn execute_bundle(wallet: &Wallet, bundle: AtomicMatchApiBundle) -> Result<(), eyre::Error> {
-    println!("Submitting bundle...\n");
-    let tx = bundle.settlement_tx.clone();
-    let receipt: PendingTransaction<_> = wallet.send_transaction(tx, None).await.unwrap();
-
-    println!("Successfully submitted transaction: {:#x}", receipt.tx_hash());
-    Ok(())
-}
-
-// -----------
-// | Helpers |
-// -----------
-
-/// Get a wallet from a private key environment variable
-async fn get_signer() -> Result<Wallet, eyre::Error> {
-    let provider = Provider::<Http>::try_from(RPC_URL).unwrap();
-    let chain_id = provider.get_chainid().await.unwrap().as_u64();
-    let pkey = std::env::var("PKEY").unwrap();
-    let wallet = LocalWallet::from_str(&pkey).unwrap().with_chain_id(chain_id);
-    let middleware = Arc::new(SignerMiddleware::new(provider, wallet));
-
-    Ok(middleware)
 }

--- a/examples/external_match/non_sender_receiver.rs
+++ b/examples/external_match/non_sender_receiver.rs
@@ -1,17 +1,11 @@
 //! An example requesting an external match where the message sender is not the
 //! receiver
 
-use std::{str::FromStr, sync::Arc};
-
-use ethers::middleware::Middleware;
-use ethers::prelude::*;
 use renegade_sdk::{
-    types::{AtomicMatchApiBundle, ExternalOrder, OrderSide},
+    example_utils::{build_renegade_client, execute_bundle, get_signer, Wallet},
+    types::{ExternalOrder, OrderSide},
     AssembleQuoteOptions, ExternalMatchClient, ExternalOrderBuilder,
 };
-
-/// The RPC URL to use
-const RPC_URL: &str = env!("RPC_URL");
 
 /// Testnet wETH
 const BASE_MINT: &str = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a";
@@ -20,19 +14,13 @@ const QUOTE_MINT: &str = "0xdf8d259c04020562717557f2b5a3cf28e92707d1";
 /// The receiver address: the address that the darkpool will send funds to
 const RECEIVER_ADDRESS: &str = "0xC5fE800A3D92112473e4E811296F194DA7b26BA7";
 
-/// The middleware type
-type Wallet = Arc<SignerMiddleware<Provider<Http>, LocalWallet>>;
-
 #[tokio::main]
 async fn main() -> Result<(), eyre::Error> {
     // Get wallet from private key
     let signer = get_signer().await?;
 
     // Get the external match client
-    let api_key = std::env::var("EXTERNAL_MATCH_KEY").unwrap();
-    let api_secret = std::env::var("EXTERNAL_MATCH_SECRET").unwrap();
-    let client = ExternalMatchClient::new_sepolia_client(&api_key, &api_secret).unwrap();
-
+    let client = build_renegade_client()?;
     let order = ExternalOrderBuilder::new()
         .base_mint(BASE_MINT)
         .quote_mint(QUOTE_MINT)
@@ -68,29 +56,4 @@ async fn fetch_quote_and_execute(
         None => eyre::bail!("No bundle found"),
     };
     execute_bundle(wallet, resp.match_bundle).await
-}
-
-/// Execute a bundle directly
-async fn execute_bundle(wallet: &Wallet, bundle: AtomicMatchApiBundle) -> Result<(), eyre::Error> {
-    println!("Submitting bundle...\n");
-    let tx = bundle.settlement_tx.clone();
-    let receipt: PendingTransaction<_> = wallet.send_transaction(tx, None).await.unwrap();
-
-    println!("Successfully submitted transaction: {:#x}", receipt.tx_hash());
-    Ok(())
-}
-
-// -----------
-// | Helpers |
-// -----------
-
-/// Get a wallet from a private key environment variable
-async fn get_signer() -> Result<Wallet, eyre::Error> {
-    let provider = Provider::<Http>::try_from(RPC_URL).unwrap();
-    let chain_id = provider.get_chainid().await.unwrap().as_u64();
-    let pkey = std::env::var("PKEY").unwrap();
-    let wallet = LocalWallet::from_str(&pkey).unwrap().with_chain_id(chain_id);
-    let middleware = Arc::new(SignerMiddleware::new(provider, wallet));
-
-    Ok(middleware)
 }

--- a/examples/external_match/quote_validation.rs
+++ b/examples/external_match/quote_validation.rs
@@ -1,22 +1,13 @@
-use std::{str::FromStr, sync::Arc};
-
-use ethers::middleware::Middleware;
-use ethers::prelude::*;
 use renegade_sdk::{
-    types::{ApiExternalQuote, AtomicMatchApiBundle, ExternalOrder, OrderSide},
+    example_utils::{build_renegade_client, execute_bundle, get_signer, Wallet},
+    types::{ApiExternalQuote, ExternalOrder, OrderSide},
     ExternalMatchClient, ExternalOrderBuilder,
 };
-
-/// The RPC URL to use
-const RPC_URL: &str = env!("RPC_URL");
 
 /// Testnet wETH
 const BASE_MINT: &str = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a";
 /// Testnet USDC
 const QUOTE_MINT: &str = "0xdf8d259c04020562717557f2b5a3cf28e92707d1";
-
-/// The middleware type
-type Wallet = Arc<SignerMiddleware<Provider<Http>, LocalWallet>>;
 
 #[tokio::main]
 async fn main() -> Result<(), eyre::Error> {
@@ -24,10 +15,7 @@ async fn main() -> Result<(), eyre::Error> {
     let signer = get_signer().await?;
 
     // Get the external match client
-    let api_key = std::env::var("EXTERNAL_MATCH_KEY").unwrap();
-    let api_secret = std::env::var("EXTERNAL_MATCH_SECRET").unwrap();
-    let client = ExternalMatchClient::new_sepolia_client(&api_key, &api_secret).unwrap();
-
+    let client = build_renegade_client()?;
     let order = ExternalOrderBuilder::new()
         .base_mint(BASE_MINT)
         .quote_mint(QUOTE_MINT)
@@ -83,29 +71,4 @@ async fn validate_quote(quote: &ApiExternalQuote) -> Result<(), eyre::Error> {
     }
 
     Ok(())
-}
-
-/// Execute a bundle directly
-async fn execute_bundle(wallet: &Wallet, bundle: AtomicMatchApiBundle) -> Result<(), eyre::Error> {
-    println!("Submitting bundle...\n");
-    let tx = bundle.settlement_tx.clone();
-    let receipt: PendingTransaction<_> = wallet.send_transaction(tx, None).await.unwrap();
-
-    println!("Successfully submitted transaction: {:#x}", receipt.tx_hash());
-    Ok(())
-}
-
-// -----------
-// | Helpers |
-// -----------
-
-/// Get a wallet from a private key environment variable
-async fn get_signer() -> Result<Wallet, eyre::Error> {
-    let provider = Provider::<Http>::try_from(RPC_URL).unwrap();
-    let chain_id = provider.get_chainid().await.unwrap().as_u64();
-    let pkey = std::env::var("PKEY").unwrap();
-    let wallet = LocalWallet::from_str(&pkey).unwrap().with_chain_id(chain_id);
-    let middleware = Arc::new(SignerMiddleware::new(provider, wallet));
-
-    Ok(middleware)
 }

--- a/src/example_utils.rs
+++ b/src/example_utils.rs
@@ -1,0 +1,46 @@
+//! Utilities for the examples
+
+use alloy::providers::{Provider, ProviderBuilder};
+use alloy::signers::local::PrivateKeySigner;
+use std::str::FromStr;
+use std::sync::Arc;
+use url::Url;
+
+use crate::types::AtomicMatchApiBundle;
+use crate::ExternalMatchClient;
+
+/// The RPC URL to use
+const RPC_URL: &str = env!("RPC_URL");
+
+/// The middleware type
+pub type Wallet = Arc<dyn Provider>;
+
+/// Build a Renegade client from environment variables
+pub fn build_renegade_client() -> Result<ExternalMatchClient, eyre::Error> {
+    let api_key = std::env::var("EXTERNAL_MATCH_KEY").unwrap();
+    let api_secret = std::env::var("EXTERNAL_MATCH_SECRET").unwrap();
+    let client = ExternalMatchClient::new_sepolia_client(&api_key, &api_secret).unwrap();
+    Ok(client)
+}
+
+/// Get a wallet from a private key environment variable
+pub async fn get_signer() -> Result<Wallet, eyre::Error> {
+    let url = Url::parse(RPC_URL).unwrap();
+    let pkey = std::env::var("PKEY").unwrap();
+    let wallet = PrivateKeySigner::from_str(&pkey).unwrap();
+    let provider = ProviderBuilder::new().wallet(wallet).on_http(url);
+
+    Ok(Arc::new(provider))
+}
+
+/// Execute a bundle directly
+pub async fn execute_bundle(
+    wallet: &Wallet,
+    bundle: AtomicMatchApiBundle,
+) -> Result<(), eyre::Error> {
+    println!("Submitting bundle...\n");
+    let tx = bundle.settlement_tx.clone();
+    let hash = wallet.send_transaction(tx).await?.watch().await?;
+    println!("Successfully submitted transaction: {:#x}", hash);
+    Ok(())
+}

--- a/src/external_match_client/api_types.rs
+++ b/src/external_match_client/api_types.rs
@@ -1,7 +1,53 @@
-//! Types for the external match client
+//! API types for external matches
+//!
+//! External matches are those brokered by the darkpool between an "internal"
+//! party (one with state committed into the protocol), and an external party,
+//! one whose trade obligations are fulfilled directly through erc20 transfers;
+//! and importantly do not commit state into the protocol
+//!
+//! Endpoints here allow permissioned solvers, searchers, etc to "ping the pool"
+//! for consenting liquidity on a given token pair.
 
-use renegade_api::http::external_match::AtomicMatchApiBundle;
+// use ethers::types::transaction::eip2718::TypedTransaction;
+use alloy_rpc_types_eth::request::TransactionRequest;
 use serde::{Deserialize, Serialize};
+
+// ---------------
+// | HTTP Routes |
+// ---------------
+
+/// Returns the supported token list
+pub const GET_SUPPORTED_TOKENS_ROUTE: &str = "/v0/supported-tokens";
+/// The route for requesting a quote on an external match
+pub const REQUEST_EXTERNAL_QUOTE_ROUTE: &str = "/v0/matching-engine/quote";
+/// The route to assemble an external match quote into a settlement bundle
+pub const ASSEMBLE_EXTERNAL_MATCH_ROUTE: &str = "/v0/matching-engine/assemble-external-match";
+/// The route for requesting an atomic match
+pub const REQUEST_EXTERNAL_MATCH_ROUTE: &str = "/v0/matching-engine/request-external-match";
+
+// -------------------------------
+// | HTTP Requests and Responses |
+// -------------------------------
+
+/// The response type to fetch the supported token list
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetSupportedTokensResponse {
+    /// The supported tokens
+    pub tokens: Vec<ApiToken>,
+}
+
+/// The request type for requesting an external match
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalMatchRequest {
+    /// Whether or not to include gas estimation in the response
+    #[serde(default)]
+    pub do_gas_estimation: bool,
+    /// The receiver address of the match, if not the message sender
+    #[serde(default)]
+    pub receiver_address: Option<String>,
+    /// The external order
+    pub external_order: ExternalOrder,
+}
 
 /// The response type for requesting an external match
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -14,4 +60,199 @@ pub struct ExternalMatchResponse {
     /// refunds the gas used by the match to the configured address
     #[serde(rename = "is_sponsored", default)]
     pub gas_sponsored: bool,
+}
+
+/// The request type for a quote on an external order
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalQuoteRequest {
+    /// The external order
+    pub external_order: ExternalOrder,
+}
+
+/// The response type for a quote on an external order
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalQuoteResponse {
+    /// The signed quote
+    pub signed_quote: SignedExternalQuote,
+}
+
+/// The request type for assembling an external match quote into a settlement
+/// bundle
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AssembleExternalMatchRequest {
+    /// Whether or not to include gas estimation in the response
+    #[serde(default)]
+    pub do_gas_estimation: bool,
+    /// The receiver address of the match, if not the message sender
+    #[serde(default)]
+    pub receiver_address: Option<String>,
+    /// The updated order if any changes have been made
+    #[serde(default)]
+    pub updated_order: Option<ExternalOrder>,
+    /// The signed quote
+    pub signed_quote: SignedExternalQuote,
+}
+
+// -------------
+// | Api Types |
+// -------------
+
+/// A token in the the supported token list
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiToken {
+    /// The token address
+    pub address: String,
+    /// The token symbol
+    pub symbol: String,
+}
+
+/// A type alias for an amount used in the Renegade system
+pub type Amount = u128;
+
+/// The side of the market this order is on
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum OrderSide {
+    /// Buy side, requesting party buys the base token
+    Buy,
+    /// Sell side, requesting party sells the base token
+    Sell,
+}
+
+/// An external order
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalOrder {
+    /// The mint (erc20 address) of the quote token
+    pub quote_mint: String,
+    /// The mint (erc20 address) of the base token
+    pub base_mint: String,
+    /// The side of the market this order is on
+    pub side: OrderSide,
+    /// The base amount of the order
+    #[serde(default)]
+    pub base_amount: Amount,
+    /// The quote amount of the order
+    #[serde(default)]
+    pub quote_amount: Amount,
+    /// The minimum fill size for the order
+    #[serde(default)]
+    pub min_fill_size: Amount,
+}
+
+/// A fee take, representing the fee amounts paid to the relayer and protocol by
+/// the external party when the match is settled
+///
+/// Fees are always paid in the receive token
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct FeeTake {
+    /// The amount of fees paid to the relayer
+    pub relayer_fee: Amount,
+    /// The amount of fees paid to the protocol
+    pub protocol_fee: Amount,
+}
+
+impl FeeTake {
+    /// Get the total fee
+    pub fn total(&self) -> Amount {
+        self.relayer_fee + self.protocol_fee
+    }
+}
+
+/// An atomic match settlement bundle, sent to the client so that they may
+/// settle the match on-chain
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AtomicMatchApiBundle {
+    /// The match result
+    pub match_result: ApiExternalMatchResult,
+    /// The fees owed by the external party
+    pub fees: FeeTake,
+    /// The transfer received by the external party, net of fees
+    pub receive: ApiExternalAssetTransfer,
+    /// The transfer sent by the external party
+    pub send: ApiExternalAssetTransfer,
+    /// The transaction which settles the match on-chain
+    pub settlement_tx: TransactionRequest,
+}
+
+/// An asset transfer from an external party
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiExternalAssetTransfer {
+    /// The mint of the asset
+    pub mint: String,
+    /// The amount of the asset
+    pub amount: Amount,
+}
+
+/// An API server external match result
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiExternalMatchResult {
+    /// The mint of the quote token in the matched asset pair
+    pub quote_mint: String,
+    /// The mint of the base token in the matched asset pair
+    pub base_mint: String,
+    /// The amount of the quote token exchanged by the match
+    pub quote_amount: Amount,
+    /// The amount of the base token exchanged by the match
+    pub base_amount: Amount,
+    /// The direction of the match
+    pub direction: OrderSide,
+}
+
+/// A signed quote for an external order
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SignedExternalQuote {
+    /// The quote
+    pub quote: ApiExternalQuote,
+    /// The signature
+    pub signature: String,
+}
+
+impl SignedExternalQuote {
+    /// Get the match result from the quote
+    pub fn match_result(&self) -> ApiExternalMatchResult {
+        self.quote.match_result.clone()
+    }
+
+    /// Get the fees from the quote
+    pub fn fees(&self) -> FeeTake {
+        self.quote.fees
+    }
+
+    /// Get the receive amount from the quote
+    pub fn receive_amount(&self) -> ApiExternalAssetTransfer {
+        self.quote.receive.clone()
+    }
+
+    /// Get the send amount from the quote
+    pub fn send_amount(&self) -> ApiExternalAssetTransfer {
+        self.quote.send.clone()
+    }
+}
+
+/// A quote for an external order
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiExternalQuote {
+    /// The external order
+    pub order: ExternalOrder,
+    /// The match result
+    pub match_result: ApiExternalMatchResult,
+    /// The estimated fees for the match
+    pub fees: FeeTake,
+    /// The amount sent by the external party
+    pub send: ApiExternalAssetTransfer,
+    /// The amount received by the external party, net of fees
+    pub receive: ApiExternalAssetTransfer,
+    /// The price of the match
+    pub price: ApiTimestampedPrice,
+    /// The timestamp of the quote
+    pub timestamp: u64,
+}
+
+/// The price of a quote
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiTimestampedPrice {
+    /// The price, serialized as a string to prevent floating point precision
+    /// issues
+    pub price: String,
+    /// The timestamp, in milliseconds since the epoch
+    pub timestamp: u64,
 }

--- a/src/external_match_client/client.rs
+++ b/src/external_match_client/client.rs
@@ -1,31 +1,33 @@
 //! The client for requesting external matches
 
-use renegade_api::http::{
-    external_match::{
-        AssembleExternalMatchRequest, ExternalMatchRequest, ExternalOrder, ExternalQuoteRequest,
-        ExternalQuoteResponse, SignedExternalQuote, ASSEMBLE_EXTERNAL_MATCH_ROUTE,
-        REQUEST_EXTERNAL_MATCH_ROUTE, REQUEST_EXTERNAL_QUOTE_ROUTE,
-    },
-    GetSupportedTokensResponse, GET_SUPPORTED_TOKENS_ROUTE,
-};
-use renegade_auth_api::RENEGADE_API_KEY_HEADER;
-use renegade_common::types::hmac::HmacKey;
 use reqwest::{
     header::{HeaderMap, HeaderValue},
     StatusCode,
 };
 use url::form_urlencoded;
 
-use crate::http::RelayerHttpClient;
+use crate::{
+    api_types::{ASSEMBLE_EXTERNAL_MATCH_ROUTE, REQUEST_EXTERNAL_MATCH_ROUTE},
+    http::RelayerHttpClient,
+    util::HmacKey,
+};
 
 use super::{
-    api_types::ExternalMatchResponse, error::ExternalMatchClientError,
+    api_types::{
+        AssembleExternalMatchRequest, ExternalMatchRequest, ExternalMatchResponse, ExternalOrder,
+        ExternalQuoteRequest, ExternalQuoteResponse, GetSupportedTokensResponse,
+        SignedExternalQuote, GET_SUPPORTED_TOKENS_ROUTE, REQUEST_EXTERNAL_QUOTE_ROUTE,
+    },
+    error::ExternalMatchClientError,
     GAS_REFUND_ADDRESS_QUERY_PARAM, GAS_SPONSORSHIP_QUERY_PARAM,
 };
 
 // -------------
 // | Constants |
 // -------------
+
+/// The Renegade API key header
+pub const RENEGADE_API_KEY_HEADER: &str = "X-Renegade-Api-Key";
 
 /// The sepolia auth server base URL
 const SEPOLIA_AUTH_BASE_URL: &str = "https://testnet.auth-server.renegade.fi";

--- a/src/external_match_client/mod.rs
+++ b/src/external_match_client/mod.rs
@@ -7,15 +7,12 @@
 pub mod api_types;
 
 mod client;
+use api_types::{Amount, ExternalOrder, OrderSide};
 #[allow(deprecated)]
 pub use client::{AssembleQuoteOptions, ExternalMatchClient, ExternalMatchOptions};
 
 mod error;
 pub use error::ExternalMatchClientError;
-use num_bigint::BigUint;
-use renegade_api::http::external_match::ExternalOrder;
-use renegade_circuit_types::{order::OrderSide, Amount};
-use renegade_util::hex::biguint_from_hex_string;
 
 /// The auth server query param for requesting gas sponsorship
 pub const GAS_SPONSORSHIP_QUERY_PARAM: &str = "use_gas_sponsorship";
@@ -26,9 +23,9 @@ pub const GAS_REFUND_ADDRESS_QUERY_PARAM: &str = "refund_address";
 #[derive(Debug, Clone, Default)]
 pub struct ExternalOrderBuilder {
     /// The mint (erc20 address) of the quote token
-    quote_mint: Option<BigUint>,
+    quote_mint: Option<String>,
     /// The mint (erc20 address) of the base token
-    base_mint: Option<BigUint>,
+    base_mint: Option<String>,
     /// The amount of the order
     base_amount: Option<Amount>,
     /// The amount of the order
@@ -49,27 +46,13 @@ impl ExternalOrderBuilder {
     ///
     /// Expects the quote mint as a hex encoded string
     pub fn quote_mint(mut self, quote_mint: &str) -> Self {
-        // Don't unwrap here, we will fail in validation
-        if let Ok(mint) = biguint_from_hex_string(quote_mint) {
-            self.quote_mint = Some(mint);
-        }
-
-        self
-    }
-
-    /// Set the quote mint as a `BigUint`
-    pub fn quote_mint_biguint(mut self, quote_mint: BigUint) -> Self {
-        self.quote_mint = Some(quote_mint);
+        self.quote_mint = Some(quote_mint.to_string());
         self
     }
 
     /// Set the base mint
     pub fn base_mint(mut self, base_mint: &str) -> Self {
-        // Don't unwrap here, we will fail in validation
-        if let Ok(mint) = biguint_from_hex_string(base_mint) {
-            self.base_mint = Some(mint);
-        }
-
+        self.base_mint = Some(base_mint.to_string());
         self
     }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,6 +1,7 @@
 //! HTTP client for connecting to the relayer
 
-use renegade_common::types::hmac::HmacKey;
+use crate::util::{self, HmacKey};
+
 use reqwest::{header::HeaderMap, Client, Error};
 use serde::{de::DeserializeOwned, Serialize};
 use std::time::Duration;
@@ -97,7 +98,7 @@ impl RelayerHttpClient {
 
     /// Add authentication to the request
     fn add_auth(&self, path: &str, headers: &mut HeaderMap, body: &[u8]) {
-        renegade_api::auth::add_expiring_auth_to_headers(
+        util::add_expiring_auth_to_headers(
             path,
             headers,
             body,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,11 @@
 #![deny(unsafe_code)]
 #![deny(clippy::needless_pass_by_ref_mut)]
 
-mod external_match_client;
+pub(crate) mod external_match_client;
 mod http;
 pub mod types;
 mod util;
 
 pub use external_match_client::*;
+#[cfg(feature = "examples")]
+pub mod example_utils;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,8 @@
 //! Types for the Renegade SDK
 
-// Re-exports from other Renegade crates
-pub use renegade_api::http::external_match::{
-    ApiExternalQuote, AtomicMatchApiBundle, ExternalOrder, SignedExternalQuote,
+// We re-export these types here because they were previously re-exported here
+// from `renegade` dependencies, and we don't want to break existing code that
+// uses them.
+pub use crate::external_match_client::api_types::{
+    ApiExternalQuote, AtomicMatchApiBundle, ExternalOrder, OrderSide, SignedExternalQuote,
 };
-pub use renegade_circuit_types::order::OrderSide;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,25 +1,103 @@
 //! Utility functions for the renegade-sdk
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-/// Wrap an eyre result in a function
-#[macro_export]
-macro_rules! wrap_eyre {
-    ($x:expr) => {
-        $x.map_err(|err| eyre::eyre!(err.to_string()))
-    };
+use base64::engine::{general_purpose as b64_general_purpose, Engine};
+use hmac::Mac;
+use reqwest::header::{HeaderMap, HeaderValue};
+
+use crate::ExternalMatchClientError;
+
+/// The header namespace to include in the HMAC
+const RENEGADE_HEADER_NAMESPACE: &str = "x-renegade";
+/// Header name for the HTTP auth signature; lower cased
+pub const RENEGADE_AUTH_HEADER_NAME: &str = "x-renegade-auth";
+/// Header name for the expiration timestamp of a signature; lower cased
+pub const RENEGADE_SIG_EXPIRATION_HEADER_NAME: &str = "x-renegade-auth-expiration";
+
+// ----------------
+// | Auth Helpers |
+// ----------------
+
+/// Type alias for the hmac core implementation
+type HmacSha256 = hmac::Hmac<sha2::Sha256>;
+/// A 32 byte HMAC key
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct HmacKey([u8; 32]);
+impl HmacKey {
+    /// Create a new HMAC key from a base64 encoded string
+    pub fn from_base64_string(s: &str) -> Result<Self, ExternalMatchClientError> {
+        let bytes = b64_general_purpose::STANDARD
+            .decode(s)
+            .map_err(|_| ExternalMatchClientError::InvalidApiSecret)?;
+        Ok(Self(bytes.try_into().unwrap()))
+    }
 }
 
-/// Constructs an HTTP path by replacing URL parameters with given values
-macro_rules! construct_http_path {
-    ($base_url:expr $(, $param:expr => $value:expr)*) => {{
-        let mut url = $base_url.to_string();
-        $(
-            let placeholder = format!(":{}", $param);
-            url = url.replace(&placeholder, &$value.to_string());
-        )*
-        url
-    }};
+/// Add an auth expiration and signature to a set of headers
+pub fn add_expiring_auth_to_headers(
+    path: &str,
+    headers: &mut HeaderMap,
+    body: &[u8],
+    key: &HmacKey,
+    expiration: Duration,
+) {
+    // Add a timestamp
+    let expiration_ts = get_current_time_millis() + expiration.as_millis() as u64;
+    headers.insert(RENEGADE_SIG_EXPIRATION_HEADER_NAME, expiration_ts.into());
+
+    // Add the signature
+    let sig = create_request_signature(path, headers, body, key);
+    let b64_sig = b64_general_purpose::STANDARD_NO_PAD.encode(sig);
+    let sig_header = HeaderValue::from_str(&b64_sig).expect("b64 encoding should not fail");
+    headers.insert(RENEGADE_AUTH_HEADER_NAME, sig_header);
 }
 
-// Export macros
-pub(crate) use construct_http_path;
-pub(crate) use wrap_eyre;
+/// Create a request signature
+pub fn create_request_signature(
+    path: &str,
+    headers: &HeaderMap,
+    body: &[u8],
+    key: &HmacKey,
+) -> Vec<u8> {
+    // Compute the expected HMAC
+    let path_bytes = path.as_bytes();
+    let header_bytes = get_header_bytes(headers);
+    let payload = [path_bytes, &header_bytes, body].concat();
+
+    // Create the HMAC
+    let mut hmac = HmacSha256::new_from_slice(&key.0).expect("hmac can handle all slice lengths");
+    hmac.update(&payload);
+    hmac.finalize().into_bytes().to_vec()
+}
+
+/// Get the header bytes to validate in an HMAC
+fn get_header_bytes(headers: &HeaderMap) -> Vec<u8> {
+    let mut headers_buf = Vec::new();
+
+    // Filter out non-Renegade headers and the auth header
+    let mut renegade_headers: Vec<(String, &HeaderValue)> = headers
+        .iter()
+        .filter_map(|(k, v)| {
+            let key = k.to_string().to_lowercase();
+            if key.starts_with(RENEGADE_HEADER_NAMESPACE) && key != RENEGADE_AUTH_HEADER_NAME {
+                Some((key, v))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Sort alphabetically, then add to the buffer
+    renegade_headers.sort_by(|a, b| a.0.cmp(&b.0));
+    for (key, value) in renegade_headers {
+        headers_buf.extend_from_slice(key.as_bytes());
+        headers_buf.extend_from_slice(value.as_bytes());
+    }
+
+    headers_buf
+}
+
+/// Returns the current unix timestamp in milliseconds, represented as u64
+pub fn get_current_time_millis() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).expect("negative timestamp").as_millis() as u64
+}


### PR DESCRIPTION
### Purpose
This PR internalizes the API types used in the external match client to reduce the number of dependencies in the client.

### Testing
- [x] All examples run successfully in testnet