### PR TITLE
external_match_client: api_types, client: support in-kind sponsorship

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Cargo.lock
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Env
+**/.env*

--- a/src/external_match_client/mod.rs
+++ b/src/external_match_client/mod.rs
@@ -15,9 +15,11 @@ mod error;
 pub use error::ExternalMatchClientError;
 
 /// The auth server query param for requesting gas sponsorship
-pub const GAS_SPONSORSHIP_QUERY_PARAM: &str = "use_gas_sponsorship";
+pub const GAS_SPONSORSHIP_QUERY_PARAM: &str = "disable_gas_sponsorship";
 /// The auth server query param for the gas refund address
 pub const GAS_REFUND_ADDRESS_QUERY_PARAM: &str = "refund_address";
+/// The auth server query param for refunding gas in terms of native ETH
+pub const GAS_REFUND_NATIVE_ETH_QUERY_PARAM: &str = "refund_native_eth";
 
 /// A builder for an [`ExternalOrder`]
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
This PR enables support for in-kind gas sponsorship.

### Testing
- [x] All existing examples run as expected wrt new gas sponsorship defaults, w/o any code changes

### TODO
- Update / new examples