### PR TITLE
external_match_client: api_types: remove sponsorship info from assembly request

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renegade-sdk"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "A Rust SDK for the Renegade protocol"
 homepage = "https://renegade.fi/"

--- a/examples/external_match/in_kind_gas_sponsorship.rs
+++ b/examples/external_match/in_kind_gas_sponsorship.rs
@@ -3,7 +3,7 @@
 use renegade_sdk::{
     example_utils::{build_renegade_client, execute_bundle, get_signer, Wallet},
     types::{ExternalOrder, OrderSide},
-    AssembleQuoteOptions, ExternalMatchClient, ExternalOrderBuilder, RequestQuoteOptions,
+    ExternalMatchClient, ExternalOrderBuilder,
 };
 
 /// Testnet wETH

--- a/src/external_match_client/api_types.rs
+++ b/src/external_match_client/api_types.rs
@@ -95,9 +95,6 @@ pub struct AssembleExternalMatchRequest {
     pub updated_order: Option<ExternalOrder>,
     /// The signed quote
     pub signed_quote: ApiSignedQuote,
-    /// The signed gas sponsorship info associated with the quote,
-    /// if sponsorship was requested
-    pub gas_sponsorship_info: Option<SignedGasSponsorshipInfo>,
 }
 
 // -------------
@@ -285,6 +282,7 @@ pub struct SignedGasSponsorshipInfo {
     /// The signed gas sponsorship info
     pub gas_sponsorship_info: GasSponsorshipInfo,
     /// The auth server's signature over the gas sponsorship info
+    #[deprecated(since = "0.1.2", note = "Gas sponsorship info is no longer signed")]
     pub signature: String,
 }
 

--- a/src/external_match_client/client.rs
+++ b/src/external_match_client/client.rs
@@ -371,7 +371,6 @@ impl ExternalMatchClient {
             receiver_address: options.receiver_address,
             do_gas_estimation: options.do_gas_estimation,
             updated_order: options.updated_order,
-            gas_sponsorship_info: quote.gas_sponsorship_info,
         };
         let headers = self.get_headers()?;
 


### PR DESCRIPTION
This PR removes the `gas_sponsorship_info` field from the `AssembleExternalMatchRequest`, as this is no longer needed by the API.

### Testing:
- [x] Ran all SDK examples, asserting that they run as expected