### PR TITLE
external-match-client: api-types, client: Expose `allow_shared` option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,11 @@ name = "supported_tokens"
 path = "examples/external_match/supported_tokens.rs"
 required-features = ["examples"]
 
+[[example]]
+name = "shared_bundle"
+path = "examples/external_match/shared_bundle.rs"
+required-features = ["examples"]
+
 [features]
 default = ["external-match-client", "darkpool-client"]
 external-match-client = []

--- a/README.md
+++ b/README.md
@@ -171,5 +171,5 @@ This can be run with `cargo run --example quote_validation`.
 ### Rate Limits
 The rate limits for external match endpoints are as follows: 
 - **Quote**: 100 requests per minute
-- **Assemble**: 5 _unsettled_ bundles per minute. That is, if an assembled bundle is submitted on-chain, the rate limiter will reset. 
-If an assembled match is not settled on-chain, the rate limiter will remove one token from the per-minute allowance.
+- **Assemble (Exclusive Bundle)**: 5 _unsettled_ bundles per minute. That is, if an assembled bundle is submitted on-chain, the rate limiter will reset. 
+- **Assemble (Shared Bundle)**: 50 _unsettled_ shared bundles per minute. A shared bundle is an assembled bundle that the relayer may send to multiple external parties, rather than enforcing that only one external party can settle the bundle. See [`examples/external_match/shared_bundle.rs`](examples/external_match/shared_bundle.rs) for an example of how to assemble a shared bundle.

--- a/examples/external_match/shared_bundle.rs
+++ b/examples/external_match/shared_bundle.rs
@@ -1,0 +1,55 @@
+use renegade_sdk::example_utils::{build_renegade_client, execute_bundle, get_signer, Wallet};
+use renegade_sdk::AssembleQuoteOptions;
+use renegade_sdk::{
+    types::{ExternalOrder, OrderSide},
+    ExternalMatchClient, ExternalOrderBuilder,
+};
+
+/// Testnet wETH
+const BASE_MINT: &str = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a";
+/// Testnet USDC
+const QUOTE_MINT: &str = "0xdf8d259c04020562717557f2b5a3cf28e92707d1";
+
+#[tokio::main]
+async fn main() -> Result<(), eyre::Error> {
+    // Get wallet from private key
+    let signer = get_signer().await?;
+
+    // Get the external match client
+    let client = build_renegade_client()?;
+    let order = ExternalOrderBuilder::new()
+        .base_mint(BASE_MINT)
+        .quote_mint(QUOTE_MINT)
+        .quote_amount(30_000_000) // $30 USDC
+        .min_fill_size(30_000_000) // $30 USDC
+        .side(OrderSide::Sell)
+        .build()
+        .unwrap();
+
+    fetch_quote_and_execute(&client, order, &signer).await?;
+    Ok(())
+}
+
+/// Fetch a quote from the external api and print it
+async fn fetch_quote_and_execute(
+    client: &ExternalMatchClient,
+    order: ExternalOrder,
+    wallet: &Wallet,
+) -> Result<(), eyre::Error> {
+    // Fetch a quote from the relayer
+    println!("Fetching quote...");
+    let res = client.request_quote(order.clone()).await?;
+    let quote = match res {
+        Some(quote) => quote,
+        None => eyre::bail!("No quote found"),
+    };
+
+    // Assemble the quote into a bundle
+    println!("Assembling quote...");
+    let options = AssembleQuoteOptions::new().with_allow_shared(true);
+    let resp = match client.assemble_quote_with_options(quote, options).await? {
+        Some(resp) => resp,
+        None => eyre::bail!("No bundle found"),
+    };
+    execute_bundle(wallet, resp.match_bundle).await
+}

--- a/src/external_match_client/api_types.rs
+++ b/src/external_match_client/api_types.rs
@@ -87,6 +87,12 @@ pub struct AssembleExternalMatchRequest {
     /// Whether or not to include gas estimation in the response
     #[serde(default)]
     pub do_gas_estimation: bool,
+    /// Whether or not to allow shared access to the resulting bundle
+    ///
+    /// If true, the bundle may be sent to other clients requesting an external
+    /// match. If false, the bundle will be exclusively held for some time
+    #[serde(default)]
+    pub allow_shared: bool,
     /// The receiver address of the match, if not the message sender
     #[serde(default)]
     pub receiver_address: Option<String>,

--- a/src/external_match_client/client.rs
+++ b/src/external_match_client/client.rs
@@ -165,6 +165,11 @@ impl ExternalMatchOptions {
 pub struct AssembleQuoteOptions {
     /// Whether to do gas estimation
     pub do_gas_estimation: bool,
+    /// Whether or not to allow shared access to the resulting bundle
+    ///
+    /// If true, the bundle may be sent to other clients requesting an external
+    /// match. If false, the bundle will be exclusively held for some time
+    pub allow_shared: bool,
     /// Whether or not to request gas sponsorship for the match
     ///
     /// If granted, the auth server will sign the bundle to indicate that the
@@ -201,6 +206,12 @@ impl AssembleQuoteOptions {
     /// Set the gas estimation flag
     pub fn with_gas_estimation(mut self, do_gas_estimation: bool) -> Self {
         self.do_gas_estimation = do_gas_estimation;
+        self
+    }
+
+    /// Set the allow shared flag
+    pub fn with_allow_shared(mut self, allow_shared: bool) -> Self {
+        self.allow_shared = allow_shared;
         self
     }
 
@@ -370,6 +381,7 @@ impl ExternalMatchClient {
             signed_quote,
             receiver_address: options.receiver_address,
             do_gas_estimation: options.do_gas_estimation,
+            allow_shared: options.allow_shared,
             updated_order: options.updated_order,
         };
         let headers = self.get_headers()?;


### PR DESCRIPTION
### Purpose
This PR adds the `allow_shared` option to the assemble options in the SDK and adds an example using the `allow_shared` flag.

### Testing
- [x] Example runs successfully in testnet