### PR TITLE
external-match-client: Add methods for malleable matches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ alloy-rpc-types-eth = "0.12"
 # === Misc === #
 base64 = "0.22"
 eyre = "0.6.10"
-num-bigint = "0.4.3"
+num-bigint = { version = "0.4.3", features = ["serde"] }
 thiserror = "1.0.31"
 url = "2.5.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,11 @@ name = "shared_bundle"
 path = "examples/external_match/shared_bundle.rs"
 required-features = ["examples"]
 
+[[example]]
+name = "malleable_match"
+path = "examples/external_match/malleable_match.rs"
+required-features = ["examples"]
+
 [features]
 default = ["external-match-client", "darkpool-client"]
 external-match-client = []
@@ -71,8 +76,10 @@ alloy-rpc-types-eth = "0.12"
 
 # === Misc === #
 base64 = "0.22"
+bigdecimal = "0.4.0"
 eyre = "0.6.10"
 num-bigint = { version = "0.4.3", features = ["serde"] }
+num-traits = "0.2.19"
 thiserror = "1.0.31"
 url = "2.5.0"
 

--- a/examples/external_match/external_match.rs
+++ b/examples/external_match/external_match.rs
@@ -49,5 +49,5 @@ async fn fetch_quote_and_execute(
         Some(resp) => resp,
         None => eyre::bail!("No bundle found"),
     };
-    execute_bundle(wallet, resp.match_bundle).await
+    execute_bundle(wallet, resp.match_bundle.settlement_tx).await
 }

--- a/examples/external_match/in_kind_gas_sponsorship.rs
+++ b/examples/external_match/in_kind_gas_sponsorship.rs
@@ -69,5 +69,5 @@ async fn fetch_quote_and_execute(
     if !resp.gas_sponsored {
         eyre::bail!("Bundle was not sponsored");
     }
-    execute_bundle(wallet, resp.match_bundle).await
+    execute_bundle(wallet, resp.match_bundle.settlement_tx).await
 }

--- a/examples/external_match/malleable_match.rs
+++ b/examples/external_match/malleable_match.rs
@@ -1,0 +1,74 @@
+use renegade_sdk::example_utils::{build_renegade_client, execute_bundle, get_signer, Wallet};
+use renegade_sdk::{
+    types::{ExternalOrder, OrderSide},
+    ExternalMatchClient, ExternalOrderBuilder,
+};
+
+/// Testnet wETH
+const BASE_MINT: &str = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a";
+/// Testnet USDC
+const QUOTE_MINT: &str = "0xdf8d259c04020562717557f2b5a3cf28e92707d1";
+
+#[tokio::main]
+async fn main() -> Result<(), eyre::Error> {
+    // Get wallet from private key
+    let signer = get_signer().await?;
+
+    // Get the external match client
+    let client = build_renegade_client()?;
+    let order = ExternalOrderBuilder::new()
+        .base_mint(BASE_MINT)
+        .quote_mint(QUOTE_MINT)
+        .quote_amount(30_000_000) // $30 USDC
+        .min_fill_size(1_000_000) // $1 USDC
+        .side(OrderSide::Sell)
+        .build()
+        .unwrap();
+
+    fetch_quote_and_execute_malleable(&client, order, &signer).await?;
+    Ok(())
+}
+
+/// Fetch a quote from the external api and execute a malleable match
+///
+/// Malleable matches allow the exact swap amount to be determined at settlement
+/// time within a predefined range, offering more flexibility than standard
+/// matches.
+async fn fetch_quote_and_execute_malleable(
+    client: &ExternalMatchClient,
+    order: ExternalOrder,
+    wallet: &Wallet,
+) -> Result<(), eyre::Error> {
+    // Fetch a quote from the relayer
+    println!("Fetching quote...");
+    let res = client.request_quote(order).await?;
+    let quote = match res {
+        Some(quote) => quote,
+        None => eyre::bail!("No quote found"),
+    };
+
+    // Assemble the quote into a malleable bundle
+    println!("Assembling malleable quote...");
+    let resp = match client.assemble_malleable_quote(quote).await? {
+        Some(resp) => resp,
+        None => eyre::bail!("No malleable bundle found"),
+    };
+
+    // Print information about the malleable match
+    let bundle = &resp.match_bundle;
+    let result = &bundle.match_result;
+
+    println!("Malleable match details:");
+    println!("  Direction: {:?}", result.direction);
+    println!("  Price: {}", result.price);
+    println!("  Min base amount: {}", result.min_base_amount);
+    println!("  Max base amount: {}", result.max_base_amount);
+
+    println!("Fee rates:");
+    println!("  Relayer fee rate: {}", bundle.fee_rates.relayer_fee_rate);
+    println!("  Protocol fee rate: {}", bundle.fee_rates.protocol_fee_rate);
+
+    // Execute the bundle
+    println!("Executing malleable match bundle...");
+    execute_bundle(wallet, bundle.settlement_tx.clone()).await
+}

--- a/examples/external_match/modify_order_after_quote.rs
+++ b/examples/external_match/modify_order_after_quote.rs
@@ -57,5 +57,5 @@ async fn fetch_quote_and_execute(
         Some(resp) => resp,
         None => eyre::bail!("No bundle found"),
     };
-    execute_bundle(wallet, resp.match_bundle).await
+    execute_bundle(wallet, resp.match_bundle.settlement_tx).await
 }

--- a/examples/external_match/native_eth_gas_sponsorship.rs
+++ b/examples/external_match/native_eth_gas_sponsorship.rs
@@ -69,5 +69,5 @@ async fn fetch_quote_and_execute(
     if !resp.gas_sponsored {
         eyre::bail!("Bundle was not sponsored");
     }
-    execute_bundle(wallet, resp.match_bundle).await
+    execute_bundle(wallet, resp.match_bundle.settlement_tx).await
 }

--- a/examples/external_match/non_sender_receiver.rs
+++ b/examples/external_match/non_sender_receiver.rs
@@ -55,5 +55,5 @@ async fn fetch_quote_and_execute(
         Some(resp) => resp,
         None => eyre::bail!("No bundle found"),
     };
-    execute_bundle(wallet, resp.match_bundle).await
+    execute_bundle(wallet, resp.match_bundle.settlement_tx).await
 }

--- a/examples/external_match/quote_validation.rs
+++ b/examples/external_match/quote_validation.rs
@@ -51,7 +51,7 @@ async fn fetch_quote_and_execute(
         Some(resp) => resp,
         None => eyre::bail!("No bundle found"),
     };
-    execute_bundle(wallet, resp.match_bundle).await
+    execute_bundle(wallet, resp.match_bundle.settlement_tx).await
 }
 
 /// Validate a quote

--- a/examples/external_match/shared_bundle.rs
+++ b/examples/external_match/shared_bundle.rs
@@ -51,5 +51,5 @@ async fn fetch_quote_and_execute(
         Some(resp) => resp,
         None => eyre::bail!("No bundle found"),
     };
-    execute_bundle(wallet, resp.match_bundle).await
+    execute_bundle(wallet, resp.match_bundle.settlement_tx).await
 }

--- a/src/example_utils.rs
+++ b/src/example_utils.rs
@@ -2,11 +2,11 @@
 
 use alloy::providers::{Provider, ProviderBuilder};
 use alloy::signers::local::PrivateKeySigner;
+use alloy_rpc_types_eth::TransactionRequest;
 use std::str::FromStr;
 use std::sync::Arc;
 use url::Url;
 
-use crate::types::AtomicMatchApiBundle;
 use crate::ExternalMatchClient;
 
 /// The RPC URL to use
@@ -34,12 +34,8 @@ pub async fn get_signer() -> Result<Wallet, eyre::Error> {
 }
 
 /// Execute a bundle directly
-pub async fn execute_bundle(
-    wallet: &Wallet,
-    bundle: AtomicMatchApiBundle,
-) -> Result<(), eyre::Error> {
+pub async fn execute_bundle(wallet: &Wallet, tx: TransactionRequest) -> Result<(), eyre::Error> {
     println!("Submitting bundle...\n");
-    let tx = bundle.settlement_tx.clone();
     let hash = wallet.send_transaction(tx).await?.watch().await?;
     println!("Successfully submitted transaction: {:#x}", hash);
     Ok(())

--- a/src/external_match_client/api_types/fixed_point.rs
+++ b/src/external_match_client/api_types/fixed_point.rs
@@ -3,7 +3,11 @@
 //! This implementation internalizes a subset of the functionality available to
 //! the fixed point type, to avoid depending on the relayer crates
 
+use std::fmt::{self, Display};
+
+use bigdecimal::{BigDecimal, ToPrimitive};
 use num_bigint::BigUint;
+use num_traits::Num;
 use serde::{Deserialize, Serialize};
 
 use super::order_types::Amount;
@@ -18,7 +22,7 @@ fn fixed_point_precision_shift() -> BigUint {
 }
 
 /// A fixed point number
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
 pub struct FixedPoint {
     /// The value of the fixed point number
     pub value: BigUint,
@@ -35,5 +39,42 @@ impl FixedPoint {
         let product = self.value.clone() * amount;
         let floor = product / fixed_point_precision_shift();
         floor.try_into().expect("fixed point overflow")
+    }
+
+    /// Convert a fixed point number to an `f64`
+    pub fn to_f64(&self) -> f64 {
+        let value_bigdec = BigDecimal::from_biguint(self.value.clone(), 0);
+        let result = &value_bigdec / FIXED_POINT_PRECISION_SHIFT;
+        result.to_f64().expect("fixed point overflow")
+    }
+}
+
+impl Display for FixedPoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_f64())
+    }
+}
+
+// Serialize and deserialize using a string representation as is done in the
+// relayer api
+impl Serialize for FixedPoint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.value.to_str_radix(10 /* radix */).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for FixedPoint {
+    fn deserialize<D>(deserializer: D) -> Result<FixedPoint, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let decimal_string = String::deserialize(deserializer)?;
+        let value = BigUint::from_str_radix(&decimal_string, 10 /* radix */)
+            .map_err(|e| serde::de::Error::custom(e.to_string()))?;
+
+        Ok(Self { value })
     }
 }

--- a/src/external_match_client/api_types/fixed_point.rs
+++ b/src/external_match_client/api_types/fixed_point.rs
@@ -1,0 +1,39 @@
+//! Fixed point implementation for the external match client
+//!
+//! This implementation internalizes a subset of the functionality available to
+//! the fixed point type, to avoid depending on the relayer crates
+
+use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
+
+use super::order_types::Amount;
+
+/// The number of bits to use for the fixed point precision
+const FIXED_POINT_PRECISION_BITS: u64 = 63;
+/// The fixed point precision shift value
+const FIXED_POINT_PRECISION_SHIFT: u64 = 1u64 << FIXED_POINT_PRECISION_BITS;
+/// Get a `BigUint` representing the fixed point precision shift value
+fn fixed_point_precision_shift() -> BigUint {
+    BigUint::from(FIXED_POINT_PRECISION_SHIFT)
+}
+
+/// A fixed point number
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FixedPoint {
+    /// The value of the fixed point number
+    pub value: BigUint,
+}
+
+impl FixedPoint {
+    /// Create a new fixed point number
+    pub fn new(value: BigUint) -> Self {
+        Self { value }
+    }
+
+    /// Multiply a fixed point number by an `Amount` and return the floor
+    pub fn floor_mul_int(&self, amount: Amount) -> Amount {
+        let product = self.value.clone() * amount;
+        let floor = product / fixed_point_precision_shift();
+        floor.try_into().expect("fixed point overflow")
+    }
+}

--- a/src/external_match_client/api_types/mod.rs
+++ b/src/external_match_client/api_types/mod.rs
@@ -1,0 +1,24 @@
+//! Types for the external match client
+mod fixed_point;
+mod order_types;
+mod request_response;
+
+pub use fixed_point::*;
+pub use order_types::*;
+pub use request_response::*;
+
+// ---------------
+// | HTTP Routes |
+// ---------------
+
+/// Returns the supported token list
+pub const GET_SUPPORTED_TOKENS_ROUTE: &str = "/v0/supported-tokens";
+/// The route for requesting a quote on an external match
+pub const REQUEST_EXTERNAL_QUOTE_ROUTE: &str = "/v0/matching-engine/quote";
+/// The route used to assemble an external match quote into a settlement bundle
+pub const ASSEMBLE_EXTERNAL_MATCH_ROUTE: &str = "/v0/matching-engine/assemble-external-match";
+/// The route used to assemble an external match into a malleable bundle
+pub const ASSEMBLE_EXTERNAL_MATCH_MALLEABLE_ROUTE: &str =
+    "/v0/matching-engine/assemble-malleable-external-match";
+/// The route for requesting an atomic match
+pub const REQUEST_EXTERNAL_MATCH_ROUTE: &str = "/v0/matching-engine/request-external-match";

--- a/src/external_match_client/api_types/order_types.rs
+++ b/src/external_match_client/api_types/order_types.rs
@@ -1,107 +1,9 @@
-//! API types for external matches
-//!
-//! External matches are those brokered by the darkpool between an "internal"
-//! party (one with state committed into the protocol), and an external party,
-//! one whose trade obligations are fulfilled directly through erc20 transfers;
-//! and importantly do not commit state into the protocol
-//!
-//! Endpoints here allow permissioned solvers, searchers, etc to "ping the pool"
-//! for consenting liquidity on a given token pair.
+//! Order types for the external match client
 
-// use ethers::types::transaction::eip2718::TypedTransaction;
-use alloy_rpc_types_eth::request::TransactionRequest;
+use alloy_rpc_types_eth::TransactionRequest;
 use serde::{Deserialize, Serialize};
 
-// ---------------
-// | HTTP Routes |
-// ---------------
-
-/// Returns the supported token list
-pub const GET_SUPPORTED_TOKENS_ROUTE: &str = "/v0/supported-tokens";
-/// The route for requesting a quote on an external match
-pub const REQUEST_EXTERNAL_QUOTE_ROUTE: &str = "/v0/matching-engine/quote";
-/// The route to assemble an external match quote into a settlement bundle
-pub const ASSEMBLE_EXTERNAL_MATCH_ROUTE: &str = "/v0/matching-engine/assemble-external-match";
-/// The route for requesting an atomic match
-pub const REQUEST_EXTERNAL_MATCH_ROUTE: &str = "/v0/matching-engine/request-external-match";
-
-// -------------------------------
-// | HTTP Requests and Responses |
-// -------------------------------
-
-/// The response type to fetch the supported token list
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct GetSupportedTokensResponse {
-    /// The supported tokens
-    pub tokens: Vec<ApiToken>,
-}
-
-/// The request type for requesting an external match
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ExternalMatchRequest {
-    /// Whether or not to include gas estimation in the response
-    #[serde(default)]
-    pub do_gas_estimation: bool,
-    /// The receiver address of the match, if not the message sender
-    #[serde(default)]
-    pub receiver_address: Option<String>,
-    /// The external order
-    pub external_order: ExternalOrder,
-}
-
-/// The response type for requesting an external match
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ExternalMatchResponse {
-    /// The raw response from the relayer
-    pub match_bundle: AtomicMatchApiBundle,
-    /// Whether the match has received gas sponsorship
-    ///
-    /// If `true`, the bundle is routed through a gas rebate contract that
-    /// refunds the gas used by the match to the configured address
-    #[serde(rename = "is_sponsored", default)]
-    pub gas_sponsored: bool,
-    /// The gas sponsorship info, if the match was sponsored
-    pub gas_sponsorship_info: Option<GasSponsorshipInfo>,
-}
-
-/// The request type for a quote on an external order
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ExternalQuoteRequest {
-    /// The external order
-    pub external_order: ExternalOrder,
-}
-
-/// The response type for a quote on an external order
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ExternalQuoteResponse {
-    /// The signed quote
-    pub signed_quote: ApiSignedQuote,
-    /// The signed gas sponsorship info, if sponsorship was requested
-    pub gas_sponsorship_info: Option<SignedGasSponsorshipInfo>,
-}
-
-/// The request type for assembling an external match quote into a settlement
-/// bundle
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AssembleExternalMatchRequest {
-    /// Whether or not to include gas estimation in the response
-    #[serde(default)]
-    pub do_gas_estimation: bool,
-    /// Whether or not to allow shared access to the resulting bundle
-    ///
-    /// If true, the bundle may be sent to other clients requesting an external
-    /// match. If false, the bundle will be exclusively held for some time
-    #[serde(default)]
-    pub allow_shared: bool,
-    /// The receiver address of the match, if not the message sender
-    #[serde(default)]
-    pub receiver_address: Option<String>,
-    /// The updated order if any changes have been made
-    #[serde(default)]
-    pub updated_order: Option<ExternalOrder>,
-    /// The signed quote
-    pub signed_quote: ApiSignedQuote,
-}
+use super::FixedPoint;
 
 // -------------
 // | Api Types |
@@ -165,6 +67,57 @@ impl FeeTake {
     pub fn total(&self) -> Amount {
         self.relayer_fee + self.protocol_fee
     }
+}
+
+/// Fee rates for relayer and protocol
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FeeTakeRate {
+    /// The fee rate for the relayer
+    pub relayer_fee_rate: FixedPoint,
+    /// The fee rate for the protocol
+    pub protocol_fee_rate: FixedPoint,
+}
+
+/// An API server bounded match result
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiBoundedMatchResult {
+    /// The mint of the quote token in the matched asset pair
+    pub quote_mint: String,
+    /// The mint of the base token in the matched asset pair
+    pub base_mint: String,
+    /// The price at which the match executes
+    pub price: String,
+    /// The minimum base amount of the match
+    pub min_base_amount: Amount,
+    /// The maximum base amount of the match
+    pub max_base_amount: Amount,
+    /// The direction of the match
+    pub direction: OrderSide,
+}
+
+/// An atomic match settlement bundle using a malleable match result
+///
+/// A malleable match result is one in which the exact `base_amount` swapped
+/// is not known at the time the proof is generated, and may be changed up until
+/// it is submitted on-chain. Instead, a bounded match result gives a
+/// `min_base_amount` and a `max_base_amount`, between which the `base_amount`
+/// may take any value
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MalleableAtomicMatchApiBundle {
+    /// The match result
+    pub match_result: ApiBoundedMatchResult,
+    /// The fees owed by the external party
+    pub fee_rates: FeeTakeRate,
+    /// The maximum amount that the external party will receive
+    pub max_receive: ApiExternalAssetTransfer,
+    /// The minimum amount that the external party will receive
+    pub min_receive: ApiExternalAssetTransfer,
+    /// The maximum amount that the external party will send
+    pub max_send: ApiExternalAssetTransfer,
+    /// The minimum amount that the external party will send
+    pub min_send: ApiExternalAssetTransfer,
+    /// The transaction which settles the match on-chain
+    pub settlement_tx: TransactionRequest,
 }
 
 /// An atomic match settlement bundle, sent to the client so that they may

--- a/src/external_match_client/api_types/request_response.rs
+++ b/src/external_match_client/api_types/request_response.rs
@@ -1,0 +1,93 @@
+//! HTTP request and response types
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    ApiSignedQuote, ApiToken, AtomicMatchApiBundle, ExternalOrder, GasSponsorshipInfo,
+    MalleableAtomicMatchApiBundle, SignedGasSponsorshipInfo,
+};
+
+// -------------------------------
+// | HTTP Requests and Responses |
+// -------------------------------
+
+/// The response type to fetch the supported token list
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetSupportedTokensResponse {
+    /// The supported tokens
+    pub tokens: Vec<ApiToken>,
+}
+
+/// The request type for requesting an external match
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalMatchRequest {
+    /// Whether or not to include gas estimation in the response
+    #[serde(default)]
+    pub do_gas_estimation: bool,
+    /// The receiver address of the match, if not the message sender
+    #[serde(default)]
+    pub receiver_address: Option<String>,
+    /// The external order
+    pub external_order: ExternalOrder,
+}
+
+/// The response type for requesting an external match
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalMatchResponse {
+    /// The raw response from the relayer
+    pub match_bundle: AtomicMatchApiBundle,
+    /// Whether the match has received gas sponsorship
+    ///
+    /// If `true`, the bundle is routed through a gas rebate contract that
+    /// refunds the gas used by the match to the configured address
+    #[serde(rename = "is_sponsored", default)]
+    pub gas_sponsored: bool,
+    /// The gas sponsorship info, if the match was sponsored
+    pub gas_sponsorship_info: Option<GasSponsorshipInfo>,
+}
+
+/// The request type for a quote on an external order
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalQuoteRequest {
+    /// The external order
+    pub external_order: ExternalOrder,
+}
+
+/// The response type for a quote on an external order
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalQuoteResponse {
+    /// The signed quote
+    pub signed_quote: ApiSignedQuote,
+    /// The signed gas sponsorship info, if sponsorship was requested
+    pub gas_sponsorship_info: Option<SignedGasSponsorshipInfo>,
+}
+
+/// The request type for assembling an external match quote into a settlement
+/// bundle
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AssembleExternalMatchRequest {
+    /// Whether or not to include gas estimation in the response
+    #[serde(default)]
+    pub do_gas_estimation: bool,
+    /// Whether or not to allow shared access to the resulting bundle
+    ///
+    /// If true, the bundle may be sent to other clients requesting an external
+    /// match. If false, the bundle will be exclusively held for some time
+    #[serde(default)]
+    pub allow_shared: bool,
+    /// The receiver address of the match, if not the message sender
+    #[serde(default)]
+    pub receiver_address: Option<String>,
+    /// The updated order if any changes have been made
+    #[serde(default)]
+    pub updated_order: Option<ExternalOrder>,
+    /// The signed quote
+    pub signed_quote: ApiSignedQuote,
+}
+
+/// The response type for requesting a malleable quote on an external order
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MalleableExternalMatchResponse {
+    /// The match bundle
+    pub match_bundle: MalleableAtomicMatchApiBundle,
+}


### PR DESCRIPTION
### Purpose
This PR adds an SDK method for assembling a quote into a malleable match. I added an example which does so without setting the base amount -- which is defaulted to the max base amount.

### Todo
- Add methods for setting the base amount conveniently in the calldata, as well as computing receive amount, send amount, and fees.

### Testing
- [x] Malleable match example runs correctly