### PR TITLE
external-match-client: api-types: Add helpers for setting base amounts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,4 +85,5 @@ url = "2.5.0"
 
 # === Example Dependencies === #
 [dev-dependencies]
+rand = "0.8"
 tokio = { version = "1.30.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ For examples on how to configure gas sponsorship, see [`examples/external_match/
 - The gas estimate returned by `eth_estimateGas` will not reflect the rebate, as the rebate does not _reduce_ the gas cost, it merely refunds the ether paid for the gas. If you wish to understand the true gas cost ahead of time, the transaction can be simulated (e.g. with `alchemy_simulateExecution` or similar).
 - The rate limits currently sponsor up to **~500 matches/day** ($100 in gas). 
 
+## Malleable Matches
+The external match API allows for a quote to be assembled into a _malleable_ match. A malleable match is a match that specifies a range of allowable base amounts, rather than an exact amount. This can be used, for example, to fit a Renegade match into a larger route with variable output amounts. 
+
+To assemble a malleable match, use the `assemble_malleable_quote` function. This function is identical to `assemble_quote`, but returns a `MalleableExternalMatchResponse` instead of an `ExternalMatchResponse`. The [`malleable_match.rs`](src/external_match_client/api_types/malleable_match.rs) example shows how to use the helper methods on the `MalleableExternalMatchResponse` to set the base amount and compute information about the bundle at a given base amount.
+
 ## Gas Estimation
 
 You can also request that the relayer estimate gas for the settlement transaction by using `request_external_match_with_options` as below:

--- a/src/external_match_client/api_types/fixed_point.rs
+++ b/src/external_match_client/api_types/fixed_point.rs
@@ -3,7 +3,10 @@
 //! This implementation internalizes a subset of the functionality available to
 //! the fixed point type, to avoid depending on the relayer crates
 
-use std::fmt::{self, Display};
+use std::{
+    fmt::{self, Display},
+    ops::Add,
+};
 
 use bigdecimal::{BigDecimal, ToPrimitive};
 use num_bigint::BigUint;
@@ -46,6 +49,15 @@ impl FixedPoint {
         let value_bigdec = BigDecimal::from_biguint(self.value.clone(), 0);
         let result = &value_bigdec / FIXED_POINT_PRECISION_SHIFT;
         result.to_f64().expect("fixed point overflow")
+    }
+}
+
+impl<'a> Add<&'a FixedPoint> for &'a FixedPoint {
+    type Output = FixedPoint;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let new_value = &self.value + &rhs.value;
+        FixedPoint::new(new_value)
     }
 }
 

--- a/src/external_match_client/api_types/malleable_match.rs
+++ b/src/external_match_client/api_types/malleable_match.rs
@@ -1,0 +1,140 @@
+//! Type for operating on a malleable match result
+
+use alloy::{primitives::U256, sol_types::SolValue};
+use alloy_rpc_types_eth::TransactionRequest;
+
+use crate::ExternalMatchClientError;
+
+use super::{MalleableExternalMatchResponse, OrderSide};
+
+/// The offset of the base amount in the calldata
+const BASE_AMOUNT_OFFSET: usize = 4;
+/// The length of the base amount in the calldata
+const BASE_AMOUNT_LENGTH: usize = 32;
+
+/// The error emitted when a selected base amount is not in the valid range
+const ERR_INVALID_BASE_AMOUNT: &str = "invalid base amount";
+
+impl MalleableExternalMatchResponse {
+    /// Get a settlement transaction with the current base amount
+    pub fn settlement_tx(&self) -> TransactionRequest {
+        self.match_bundle.settlement_tx.clone()
+    }
+
+    /// Set the `base_amount` of the `match_result`
+    ///
+    /// Returns the amount received at the given base amount
+    pub fn set_base_amount(&mut self, base_amount: u128) -> Result<u128, ExternalMatchClientError> {
+        self.check_base_amount(base_amount)?;
+
+        // Set the calldata
+        self.set_base_amount_calldata(base_amount);
+        self.base_amount = Some(base_amount);
+        Ok(self.receive_amount())
+    }
+
+    /// Set the calldata to use a given base amount
+    pub fn set_base_amount_calldata(&mut self, base_amount: u128) {
+        let mut modified_data = self.tx_data();
+        let base_amt_slice =
+            &mut modified_data[BASE_AMOUNT_OFFSET..BASE_AMOUNT_OFFSET + BASE_AMOUNT_LENGTH];
+
+        let base_amount_u256 = U256::from(base_amount);
+        let base_bytes = base_amount_u256.abi_encode();
+        base_amt_slice.copy_from_slice(&base_bytes);
+        self.match_bundle.settlement_tx.input.data = Some(modified_data.into());
+    }
+
+    /// Get the bounds on the base amount
+    ///
+    /// Returns a tuple [min_amount, max_amount] inclusive
+    pub fn base_bounds(&self) -> (u128, u128) {
+        (
+            self.match_bundle.match_result.min_base_amount,
+            self.match_bundle.match_result.max_base_amount,
+        )
+    }
+
+    /// Get the receive amount at the currently set base amount
+    pub fn receive_amount(&self) -> u128 {
+        self.compute_receive_amount(self.current_base_amount())
+    }
+
+    /// Get the receive amount at the given base amount
+    pub fn receive_amount_at_base(&self, base_amount: u128) -> u128 {
+        self.compute_receive_amount(base_amount)
+    }
+
+    /// Get the send amount at the currently set base amount
+    pub fn send_amount(&self) -> u128 {
+        self.compute_send_amount(self.current_base_amount())
+    }
+
+    /// Get the send amount at the given base amount
+    pub fn send_amount_at_base(&self, base_amount: u128) -> u128 {
+        self.compute_send_amount(base_amount)
+    }
+
+    // --- Private Helpers --- //
+
+    /// Check a base amount is in the valid range
+    fn check_base_amount(&self, base_amount: u128) -> Result<(), ExternalMatchClientError> {
+        let min = self.match_bundle.match_result.min_base_amount;
+        let max = self.match_bundle.match_result.max_base_amount;
+        if base_amount < min || base_amount > max {
+            return Err(ExternalMatchClientError::invalid_modification(ERR_INVALID_BASE_AMOUNT));
+        }
+
+        Ok(())
+    }
+
+    /// Get the current receive amount at the given base amount
+    ///
+    /// This is net of fees
+    fn compute_receive_amount(&self, base_amount: u128) -> u128 {
+        let match_res = &self.match_bundle.match_result;
+        let mut pre_sponsored_amt = match match_res.direction {
+            OrderSide::Buy => base_amount,
+            OrderSide::Sell => self.quote_amount(base_amount),
+        };
+
+        // Account for fees
+        let total_fee = self.match_bundle.fee_rates.total();
+        let total_fee_amount = total_fee.floor_mul_int(pre_sponsored_amt);
+        pre_sponsored_amt -= total_fee_amount;
+
+        // Account for gas sponsorship
+        if let Some(info) = &self.gas_sponsorship_info {
+            if !info.refund_native_eth {
+                pre_sponsored_amt += info.refund_amount;
+            }
+        };
+
+        pre_sponsored_amt
+    }
+
+    /// Get the current send amount at the given base amount
+    fn compute_send_amount(&self, base_amount: u128) -> u128 {
+        let match_res = &self.match_bundle.match_result;
+        match match_res.direction {
+            OrderSide::Buy => self.quote_amount(base_amount),
+            OrderSide::Sell => base_amount,
+        }
+    }
+
+    /// Get the quote amount at the given base amount
+    fn quote_amount(&self, base_amount: u128) -> u128 {
+        self.match_bundle.match_result.price_fp.floor_mul_int(base_amount)
+    }
+
+    /// Get the current base amount
+    fn current_base_amount(&self) -> u128 {
+        self.base_amount.unwrap_or(self.match_bundle.match_result.max_base_amount)
+    }
+
+    /// Get the tx data
+    fn tx_data(&self) -> Vec<u8> {
+        let data = self.match_bundle.settlement_tx.input.data.clone();
+        data.unwrap_or_default().to_vec()
+    }
+}

--- a/src/external_match_client/api_types/mod.rs
+++ b/src/external_match_client/api_types/mod.rs
@@ -1,5 +1,6 @@
 //! Types for the external match client
 mod fixed_point;
+mod malleable_match;
 mod order_types;
 mod request_response;
 

--- a/src/external_match_client/api_types/order_types.rs
+++ b/src/external_match_client/api_types/order_types.rs
@@ -78,6 +78,13 @@ pub struct FeeTakeRate {
     pub protocol_fee_rate: FixedPoint,
 }
 
+impl FeeTakeRate {
+    /// Get the total fee rate
+    pub fn total(&self) -> FixedPoint {
+        &self.relayer_fee_rate + &self.protocol_fee_rate
+    }
+}
+
 /// An API server bounded match result
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ApiBoundedMatchResult {
@@ -86,7 +93,7 @@ pub struct ApiBoundedMatchResult {
     /// The mint of the base token in the matched asset pair
     pub base_mint: String,
     /// The price at which the match executes
-    pub price: String,
+    pub price_fp: FixedPoint,
     /// The minimum base amount of the match
     pub min_base_amount: Amount,
     /// The maximum base amount of the match

--- a/src/external_match_client/api_types/request_response.rs
+++ b/src/external_match_client/api_types/request_response.rs
@@ -90,4 +90,16 @@ pub struct AssembleExternalMatchRequest {
 pub struct MalleableExternalMatchResponse {
     /// The match bundle
     pub match_bundle: MalleableAtomicMatchApiBundle,
+    /// The base amount chosen for the match
+    ///
+    /// If `None`, the base amount has not been selected and will default to the
+    /// `max_base_amount`
+    ///
+    /// This field is not meant for client use directly, rather it is set by
+    /// operating on the type and allows the response type to stay internally
+    /// consistent
+    #[serde(default)]
+    pub(crate) base_amount: Option<u128>,
+    /// The gas sponsorship info, if the match was sponsored
+    pub gas_sponsorship_info: Option<GasSponsorshipInfo>,
 }

--- a/src/external_match_client/error.rs
+++ b/src/external_match_client/error.rs
@@ -17,6 +17,9 @@ pub enum ExternalMatchClientError {
     /// An error indicating that the api secret is invalid
     #[error("the api secret is invalid")]
     InvalidApiSecret,
+    /// An invalid modification to a malleable match
+    #[error("invalid modification to a malleable match: {0}")]
+    InvalidModification(String),
     /// An error indicating that an order is invalid
     #[error("invalid order: {0}")]
     InvalidOrder(String),
@@ -29,6 +32,12 @@ impl ExternalMatchClientError {
     /// Construct a new http error
     pub(crate) fn http<T: ToString>(status: StatusCode, msg: T) -> Self {
         Self::Http(Some(status), msg.to_string())
+    }
+
+    /// Construct a new invalid modification error
+    #[allow(clippy::needless_pass_by_value)]
+    pub(crate) fn invalid_modification<T: ToString>(msg: T) -> Self {
+        Self::InvalidModification(msg.to_string())
     }
 
     /// Construct a new invalid order error


### PR DESCRIPTION
### Purpose
This PR adds helpers for setting the base amount in a malleable match, including helpers to compute the send and receive amounts given a counterfactual base amount. These helpers all include gas sponsorship and represent the "all in" price. 

### Testing
- [x] Example passes and reported send and receive amounts match those executed on-chain