### PR TITLE
external-match-client: malleable-match: Fix `value` on native eth sell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renegade-sdk"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "A Rust SDK for the Renegade protocol"
 homepage = "https://renegade.fi/"

--- a/src/external_match_client/api_types/order_types.rs
+++ b/src/external_match_client/api_types/order_types.rs
@@ -22,7 +22,7 @@ pub struct ApiToken {
 pub type Amount = u128;
 
 /// The side of the market this order is on
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum OrderSide {
     /// Buy side, requesting party buys the base token
     Buy,

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,3 +6,6 @@
 pub use crate::external_match_client::api_types::{
     ApiExternalQuote, AtomicMatchApiBundle, ExternalOrder, OrderSide, SignedExternalQuote,
 };
+
+/// The address used to represent the native asset
+pub const NATIVE_ASSET_ADDR: &str = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";


### PR DESCRIPTION
### Purpose
This PR properly sets the `value` field on the settlement transaction to the base amount swapped in the case that a malleable match is a native ETH sell.

### Testing
- [x] Tested in mainnet