### PR TITLE
external_match_client: malleable_match: allow setting quote amount

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renegade-sdk"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "A Rust SDK for the Renegade protocol"
 homepage = "https://renegade.fi/"
@@ -80,6 +80,7 @@ bigdecimal = "0.4.0"
 eyre = "0.6.10"
 num-bigint = { version = "0.4.3", features = ["serde"] }
 num-traits = "0.2.19"
+num-integer = "0.1"
 thiserror = "1.0.31"
 url = "2.5.0"
 

--- a/src/example_utils.rs
+++ b/src/example_utils.rs
@@ -37,6 +37,6 @@ pub async fn get_signer() -> Result<Wallet, eyre::Error> {
 pub async fn execute_bundle(wallet: &Wallet, tx: TransactionRequest) -> Result<(), eyre::Error> {
     println!("Submitting bundle...\n");
     let hash = wallet.send_transaction(tx).await?.watch().await?;
-    println!("Successfully submitted transaction: {:#x}", hash);
+    println!("Successfully submitted transaction: {hash:#x}");
     Ok(())
 }

--- a/src/external_match_client/api_types/fixed_point.rs
+++ b/src/external_match_client/api_types/fixed_point.rs
@@ -10,7 +10,8 @@ use std::{
 
 use bigdecimal::{BigDecimal, ToPrimitive};
 use num_bigint::BigUint;
-use num_traits::Num;
+use num_integer::Integer;
+use num_traits::{Num, One, Zero};
 use serde::{Deserialize, Serialize};
 
 use super::order_types::Amount;
@@ -42,6 +43,16 @@ impl FixedPoint {
         let product = self.value.clone() * amount;
         let floor = product / fixed_point_precision_shift();
         floor.try_into().expect("fixed point overflow")
+    }
+
+    /// Divide an `Amount` by a fixed point number and return the ceiling
+    pub fn ceil_div_int(amount: Amount, fp: &Self) -> Amount {
+        let numerator = amount * fixed_point_precision_shift();
+        let (quotient, remainder) = numerator.div_rem(&fp.value);
+
+        let result = if remainder.is_zero() { quotient } else { quotient + BigUint::one() };
+
+        result.try_into().expect("fixed point overflow")
     }
 
     /// Convert a fixed point number to an `f64`

--- a/src/external_match_client/api_types/malleable_match.rs
+++ b/src/external_match_client/api_types/malleable_match.rs
@@ -5,15 +5,23 @@ use alloy_rpc_types_eth::{TransactionInput, TransactionRequest};
 
 use crate::{types::NATIVE_ASSET_ADDR, ExternalMatchClientError};
 
-use super::{MalleableExternalMatchResponse, OrderSide};
+use super::{FixedPoint, MalleableExternalMatchResponse, OrderSide};
 
-/// The offset of the base amount in the calldata
-const BASE_AMOUNT_OFFSET: usize = 4;
-/// The length of the base amount in the calldata
-const BASE_AMOUNT_LENGTH: usize = 32;
+/// The offset of the quote amount in the calldata,
+/// which is `4` because it's the first calldata argument after the 4-byte
+/// function selector.
+const QUOTE_AMOUNT_OFFSET: usize = 4;
+/// The offset of the base amount in the calldata, which is
+/// `AMOUNT_CALLDATA_LENGTH` after the quote amount as it is the next calldata
+/// argument.
+const BASE_AMOUNT_OFFSET: usize = QUOTE_AMOUNT_OFFSET + AMOUNT_CALLDATA_LENGTH;
+/// The length of an amount in calldata, which is 32 bytes for a `uint256`
+const AMOUNT_CALLDATA_LENGTH: usize = 32;
 
 /// The error emitted when a selected base amount is not in the valid range
 const ERR_INVALID_BASE_AMOUNT: &str = "invalid base amount";
+/// The error emitted when a selected quote amount is not in the valid range
+const ERR_INVALID_QUOTE_AMOUNT: &str = "invalid quote amount";
 
 impl MalleableExternalMatchResponse {
     /// Get a settlement transaction with the current base amount
@@ -27,9 +35,16 @@ impl MalleableExternalMatchResponse {
     pub fn set_base_amount(&mut self, base_amount: u128) -> Result<u128, ExternalMatchClientError> {
         self.check_base_amount(base_amount)?;
 
+        let implied_quote_amount = self.quote_amount(base_amount);
+
         // Set the calldata
         self.set_base_amount_calldata(base_amount);
+        self.set_quote_amount_calldata(implied_quote_amount);
+
+        // Set the quote and base amounts on the response
         self.base_amount = Some(base_amount);
+        self.quote_amount = Some(implied_quote_amount);
+
         Ok(self.receive_amount())
     }
 
@@ -37,7 +52,7 @@ impl MalleableExternalMatchResponse {
     pub fn set_base_amount_calldata(&mut self, base_amount: u128) {
         let mut modified_data = self.tx_data();
         let base_amt_slice =
-            &mut modified_data[BASE_AMOUNT_OFFSET..BASE_AMOUNT_OFFSET + BASE_AMOUNT_LENGTH];
+            &mut modified_data[BASE_AMOUNT_OFFSET..BASE_AMOUNT_OFFSET + AMOUNT_CALLDATA_LENGTH];
 
         let base_amount_u256 = U256::from(base_amount);
         let base_bytes = base_amount_u256.abi_encode();
@@ -48,8 +63,43 @@ impl MalleableExternalMatchResponse {
 
         // If the trade is a native ETH sell, we need to set the `value` of the tx
         if self.is_native_eth_sell() {
-            self.match_bundle.settlement_tx.value = Some(U256::from(base_amount));
+            self.match_bundle.settlement_tx.value = Some(base_amount_u256);
         }
+    }
+
+    /// Set the `quote_amount` of the `match_result`
+    ///
+    /// Returns the amount received at the given quote amount
+    pub fn set_quote_amount(
+        &mut self,
+        quote_amount: u128,
+    ) -> Result<u128, ExternalMatchClientError> {
+        let implied_base_amount = self.base_amount(quote_amount);
+        self.check_quote_amount(quote_amount, implied_base_amount)?;
+
+        // Set the calldata
+        self.set_quote_amount_calldata(quote_amount);
+        self.set_base_amount_calldata(implied_base_amount);
+
+        // Set the quote and base amounts on the response
+        self.quote_amount = Some(quote_amount);
+        self.base_amount = Some(implied_base_amount);
+
+        Ok(self.receive_amount())
+    }
+
+    /// Set the calldata to use a given quote amount
+    pub fn set_quote_amount_calldata(&mut self, quote_amount: u128) {
+        let mut modified_data = self.tx_data();
+        let quote_amt_slice =
+            &mut modified_data[QUOTE_AMOUNT_OFFSET..QUOTE_AMOUNT_OFFSET + AMOUNT_CALLDATA_LENGTH];
+
+        let quote_amount_u256 = U256::from(quote_amount);
+        let quote_bytes = quote_amount_u256.abi_encode();
+        quote_amt_slice.copy_from_slice(&quote_bytes);
+
+        let new_input = TransactionInput::new(modified_data.into());
+        self.match_bundle.settlement_tx.input = new_input;
     }
 
     /// Get the bounds on the base amount
@@ -62,6 +112,37 @@ impl MalleableExternalMatchResponse {
         )
     }
 
+    /// Get the bounds on the quote amount
+    ///
+    /// Returns a tuple [min_amount, max_amount] inclusive
+    pub fn quote_bounds(&self) -> (u128, u128) {
+        let (min_base, max_base) = self.base_bounds();
+        let price = &self.match_bundle.match_result.price_fp;
+
+        let min_quote = price.floor_mul_int(min_base);
+        let max_quote = price.floor_mul_int(max_base);
+
+        (min_quote, max_quote)
+    }
+
+    /// Get the bounds on the quote amount for a given base amount.
+    ///
+    /// For an explanation of these bounds, see:
+    /// https://github.com/renegade-fi/renegade-contracts/blob/main/contracts-common/src/types/match.rs#L144-L174
+    pub fn quote_bounds_for_base(&self, base_amount: u128) -> (u128, u128) {
+        let (min_quote, max_quote) = self.quote_bounds();
+
+        let price = &self.match_bundle.match_result.price_fp;
+        let ref_quote = price.floor_mul_int(base_amount);
+
+        let (range_min, range_max) = match self.match_bundle.match_result.direction {
+            OrderSide::Buy => (ref_quote, max_quote),
+            OrderSide::Sell => (min_quote, ref_quote),
+        };
+
+        (range_min, range_max)
+    }
+
     /// Get the receive amount at the currently set base amount
     pub fn receive_amount(&self) -> u128 {
         self.compute_receive_amount(self.current_base_amount())
@@ -72,6 +153,12 @@ impl MalleableExternalMatchResponse {
         self.compute_receive_amount(base_amount)
     }
 
+    /// Get the receive amount at the given quote amount
+    pub fn receive_amount_at_quote(&self, quote_amount: u128) -> u128 {
+        let base_amount = self.base_amount(quote_amount);
+        self.compute_receive_amount(base_amount)
+    }
+
     /// Get the send amount at the currently set base amount
     pub fn send_amount(&self) -> u128 {
         self.compute_send_amount(self.current_base_amount())
@@ -79,6 +166,12 @@ impl MalleableExternalMatchResponse {
 
     /// Get the send amount at the given base amount
     pub fn send_amount_at_base(&self, base_amount: u128) -> u128 {
+        self.compute_send_amount(base_amount)
+    }
+
+    /// Get the send amount at the given quote amount
+    pub fn send_amount_at_quote(&self, quote_amount: u128) -> u128 {
+        let base_amount = self.base_amount(quote_amount);
         self.compute_send_amount(base_amount)
     }
 
@@ -95,10 +188,28 @@ impl MalleableExternalMatchResponse {
 
     /// Check a base amount is in the valid range
     fn check_base_amount(&self, base_amount: u128) -> Result<(), ExternalMatchClientError> {
-        let min = self.match_bundle.match_result.min_base_amount;
-        let max = self.match_bundle.match_result.max_base_amount;
+        let (min, max) = self.base_bounds();
         if base_amount < min || base_amount > max {
             return Err(ExternalMatchClientError::invalid_modification(ERR_INVALID_BASE_AMOUNT));
+        }
+
+        Ok(())
+    }
+
+    /// Check a quote amount is in the valid range for a given base amount.
+    ///
+    /// This is true if the quote amount is within the bounds implied by the min
+    /// and max base amounts given the price in the match results, and the
+    /// quote amount does not imply a price improvement over the price in
+    /// the match result.
+    fn check_quote_amount(
+        &self,
+        quote_amount: u128,
+        base_amount: u128,
+    ) -> Result<(), ExternalMatchClientError> {
+        let (min_quote, max_quote) = self.quote_bounds_for_base(base_amount);
+        if quote_amount < min_quote || quote_amount > max_quote {
+            return Err(ExternalMatchClientError::invalid_modification(ERR_INVALID_QUOTE_AMOUNT));
         }
 
         Ok(())
@@ -136,6 +247,11 @@ impl MalleableExternalMatchResponse {
             OrderSide::Buy => self.quote_amount(base_amount),
             OrderSide::Sell => base_amount,
         }
+    }
+
+    /// Get the base amount at the given quote amount
+    fn base_amount(&self, quote_amount: u128) -> u128 {
+        FixedPoint::ceil_div_int(quote_amount, &self.match_bundle.match_result.price_fp)
     }
 
     /// Get the quote amount at the given base amount

--- a/src/external_match_client/api_types/request_response.rs
+++ b/src/external_match_client/api_types/request_response.rs
@@ -100,6 +100,17 @@ pub struct MalleableExternalMatchResponse {
     /// consistent
     #[serde(default)]
     pub(crate) base_amount: Option<u128>,
+    /// The quote amount chosen for the match
+    ///
+    /// If `None`, the quote amount has not been selected and will default to
+    /// the quote amount implied by the `max_base_amount` and the price in
+    /// the match result.
+    ///
+    /// This field is not meant for client use directly, rather it is set by
+    /// operating on the type and allows the response type to stay internally
+    /// consistent
+    #[serde(default)]
+    pub(crate) quote_amount: Option<u128>,
     /// The gas sponsorship info, if the match was sponsored
     pub gas_sponsorship_info: Option<GasSponsorshipInfo>,
 }

--- a/src/external_match_client/client.rs
+++ b/src/external_match_client/client.rs
@@ -274,7 +274,7 @@ impl AssembleQuoteOptions {
             return ASSEMBLE_EXTERNAL_MATCH_ROUTE.to_string();
         }
 
-        format!("{}?{}", ASSEMBLE_EXTERNAL_MATCH_ROUTE, query_str)
+        format!("{ASSEMBLE_EXTERNAL_MATCH_ROUTE}?{query_str}")
     }
 }
 


### PR DESCRIPTION
This PR exposes a method for setting the quote amount on a malleable match, from which the base amount is derived. This comes with the necessary checks for validity of the quote amount, which mirror those in the contracts.

### TODO
- [x] Test against testnet deployment