### PR TITLE
renegade: external-match-client: Add Base client configs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renegade-sdk"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "A Rust SDK for the Renegade protocol"
 homepage = "https://renegade.fi/"
@@ -12,6 +12,11 @@ license = "MIT"
 [[example]]
 name = "external_match"
 path = "examples/external_match/external_match.rs"
+required-features = ["examples"]
+
+[[example]]
+name = "base_sepolia_match"
+path = "examples/external_match/base_sepolia_match.rs"
 required-features = ["examples"]
 
 [[example]]

--- a/examples/external_match/base_sepolia_match.rs
+++ b/examples/external_match/base_sepolia_match.rs
@@ -1,18 +1,13 @@
-//! An example requesting an external match where the message sender is not the
-//! receiver
-
+use renegade_sdk::example_utils::{build_renegade_client, execute_bundle, get_signer, Wallet};
 use renegade_sdk::{
-    example_utils::{build_renegade_client, execute_bundle, get_signer, Wallet},
     types::{ExternalOrder, OrderSide},
-    AssembleQuoteOptions, ExternalMatchClient, ExternalOrderBuilder,
+    ExternalMatchClient, ExternalOrderBuilder,
 };
 
-/// Testnet wETH
-const BASE_MINT: &str = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a";
+/// Testnet cbBTC
+const BASE_MINT: &str = "0xb51a558c8E55DE1EE5391BDFe2aFA49968FC3B25";
 /// Testnet USDC
-const QUOTE_MINT: &str = "0xdf8d259c04020562717557f2b5a3cf28e92707d1";
-/// The receiver address: the address that the darkpool will send funds to
-const RECEIVER_ADDRESS: &str = "0xC5fE800A3D92112473e4E811296F194DA7b26BA7";
+const QUOTE_MINT: &str = "0xD9961Bb4Cb27192f8dAd20a662be081f546b0E74";
 
 #[tokio::main]
 async fn main() -> Result<(), eyre::Error> {
@@ -20,13 +15,13 @@ async fn main() -> Result<(), eyre::Error> {
     let signer = get_signer().await?;
 
     // Get the external match client
-    let client = build_renegade_client(false /* use_base */)?;
+    let client = build_renegade_client(true /* use_base */)?;
     let order = ExternalOrderBuilder::new()
         .base_mint(BASE_MINT)
         .quote_mint(QUOTE_MINT)
         .quote_amount(30_000_000) // $30 USDC
         .min_fill_size(30_000_000) // $30 USDC
-        .side(OrderSide::Buy)
+        .side(OrderSide::Sell)
         .build()
         .unwrap();
 
@@ -50,8 +45,7 @@ async fn fetch_quote_and_execute(
 
     // Assemble the quote into a bundle
     println!("Assembling quote...");
-    let options = AssembleQuoteOptions::new().with_receiver_address(RECEIVER_ADDRESS.to_string());
-    let resp = match client.assemble_quote_with_options(quote, options).await? {
+    let resp = match client.assemble_quote(quote).await? {
         Some(resp) => resp,
         None => eyre::bail!("No bundle found"),
     };

--- a/examples/external_match/external_match.rs
+++ b/examples/external_match/external_match.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), eyre::Error> {
     let signer = get_signer().await?;
 
     // Get the external match client
-    let client = build_renegade_client()?;
+    let client = build_renegade_client(false /* use_base */)?;
     let order = ExternalOrderBuilder::new()
         .base_mint(BASE_MINT)
         .quote_mint(QUOTE_MINT)

--- a/examples/external_match/in_kind_gas_sponsorship.rs
+++ b/examples/external_match/in_kind_gas_sponsorship.rs
@@ -16,8 +16,7 @@ async fn main() -> Result<(), eyre::Error> {
     // Get wallet from private key
     let signer = get_signer().await?;
 
-    // Get the external match client
-    let client = build_renegade_client()?;
+    let client = build_renegade_client(false /* use_base */)?;
     let order = ExternalOrderBuilder::new()
         .base_mint(BASE_MINT)
         .quote_mint(QUOTE_MINT)

--- a/examples/external_match/malleable_match.rs
+++ b/examples/external_match/malleable_match.rs
@@ -7,9 +7,9 @@ use renegade_sdk::{
 };
 
 /// Testnet wETH
-const BASE_MINT: &str = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a";
+const BASE_MINT: &str = "0xb51a558c8E55DE1EE5391BDFe2aFA49968FC3B25";
 /// Testnet USDC
-const QUOTE_MINT: &str = "0xdf8d259c04020562717557f2b5a3cf28e92707d1";
+const QUOTE_MINT: &str = "0xD9961Bb4Cb27192f8dAd20a662be081f546b0E74";
 
 #[tokio::main]
 async fn main() -> Result<(), eyre::Error> {
@@ -17,7 +17,7 @@ async fn main() -> Result<(), eyre::Error> {
     let signer = get_signer().await?;
 
     // Get the external match client
-    let client = build_renegade_client()?;
+    let client = build_renegade_client(false /* use_base */)?;
     let order = ExternalOrderBuilder::new()
         .base_mint(BASE_MINT)
         .quote_mint(QUOTE_MINT)

--- a/examples/external_match/modify_order_after_quote.rs
+++ b/examples/external_match/modify_order_after_quote.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), eyre::Error> {
     let signer = get_signer().await?;
 
     // Get the external match client
-    let client = build_renegade_client()?;
+    let client = build_renegade_client(false /* use_base */)?;
     let order = ExternalOrderBuilder::new()
         .base_mint(BASE_MINT)
         .quote_mint(QUOTE_MINT)

--- a/examples/external_match/native_eth_gas_sponsorship.rs
+++ b/examples/external_match/native_eth_gas_sponsorship.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), eyre::Error> {
     let signer = get_signer().await?;
 
     // Get the external match client
-    let client = build_renegade_client()?;
+    let client = build_renegade_client(false /* use_base */)?;
     let order = ExternalOrderBuilder::new()
         .base_mint(BASE_MINT)
         .quote_mint(QUOTE_MINT)

--- a/examples/external_match/quote_validation.rs
+++ b/examples/external_match/quote_validation.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), eyre::Error> {
     let signer = get_signer().await?;
 
     // Get the external match client
-    let client = build_renegade_client()?;
+    let client = build_renegade_client(false /* use_base */)?;
     let order = ExternalOrderBuilder::new()
         .base_mint(BASE_MINT)
         .quote_mint(QUOTE_MINT)

--- a/examples/external_match/shared_bundle.rs
+++ b/examples/external_match/shared_bundle.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), eyre::Error> {
     let signer = get_signer().await?;
 
     // Get the external match client
-    let client = build_renegade_client()?;
+    let client = build_renegade_client(false /* use_base */)?;
     let order = ExternalOrderBuilder::new()
         .base_mint(BASE_MINT)
         .quote_mint(QUOTE_MINT)

--- a/src/example_utils.rs
+++ b/src/example_utils.rs
@@ -16,10 +16,16 @@ const RPC_URL: &str = env!("RPC_URL");
 pub type Wallet = Arc<dyn Provider>;
 
 /// Build a Renegade client from environment variables
-pub fn build_renegade_client() -> Result<ExternalMatchClient, eyre::Error> {
+pub fn build_renegade_client(use_base: bool) -> Result<ExternalMatchClient, eyre::Error> {
     let api_key = std::env::var("EXTERNAL_MATCH_KEY").unwrap();
     let api_secret = std::env::var("EXTERNAL_MATCH_SECRET").unwrap();
-    let client = ExternalMatchClient::new_arbitrum_sepolia_client(&api_key, &api_secret).unwrap();
+
+    let client = if use_base {
+        ExternalMatchClient::new_base_sepolia_client(&api_key, &api_secret).unwrap()
+    } else {
+        ExternalMatchClient::new_arbitrum_sepolia_client(&api_key, &api_secret).unwrap()
+    };
+
     Ok(client)
 }
 

--- a/src/external_match_client/client.rs
+++ b/src/external_match_client/client.rs
@@ -38,10 +38,18 @@ pub const RENEGADE_API_KEY_HEADER: &str = "X-Renegade-Api-Key";
 const ARBITRUM_SEPOLIA_AUTH_BASE_URL: &str = "https://arbitrum-sepolia.auth-server.renegade.fi";
 /// The Arbitrum One auth server base URL
 const ARBITRUM_ONE_AUTH_BASE_URL: &str = "https://arbitrum-one.auth-server.renegade.fi";
+/// The Base Sepolia auth server base URL
+const BASE_SEPOLIA_AUTH_BASE_URL: &str = "https://base-sepolia.auth-server.renegade.fi";
+/// The Base mainnet auth server base URL
+const BASE_MAINNET_AUTH_BASE_URL: &str = "https://base-mainnet.auth-server.renegade.fi";
 /// The Arbitrum Sepolia relayer base URL
 const ARBITRUM_SEPOLIA_RELAYER_BASE_URL: &str = "https://arbitrum-sepolia.relayer.renegade.fi";
 /// The Arbitrum One relayer base URL
 const ARBITRUM_ONE_RELAYER_BASE_URL: &str = "https://arbitrum-one.relayer.renegade.fi";
+/// The Base Sepolia relayer base URL
+const BASE_SEPOLIA_RELAYER_BASE_URL: &str = "https://base-sepolia.relayer.renegade.fi";
+/// The Base mainnet relayer base URL
+const BASE_MAINNET_RELAYER_BASE_URL: &str = "https://base-mainnet.relayer.renegade.fi";
 
 // -------------------
 // | Request Options |
@@ -326,6 +334,14 @@ impl ExternalMatchClient {
         )
     }
 
+    /// Create a new client for the Base Sepolia network
+    pub fn new_base_sepolia_client(
+        api_key: &str,
+        api_secret: &str,
+    ) -> Result<Self, ExternalMatchClientError> {
+        Self::new(api_key, api_secret, BASE_SEPOLIA_AUTH_BASE_URL, BASE_SEPOLIA_RELAYER_BASE_URL)
+    }
+
     /// Create a new client for the Arbitrum Sepolia network
     #[deprecated(since = "0.1.6", note = "Use new_arbitrum_sepolia_client instead")]
     pub fn new_sepolia_client(
@@ -341,6 +357,14 @@ impl ExternalMatchClient {
         api_secret: &str,
     ) -> Result<Self, ExternalMatchClientError> {
         Self::new(api_key, api_secret, ARBITRUM_ONE_AUTH_BASE_URL, ARBITRUM_ONE_RELAYER_BASE_URL)
+    }
+
+    /// Create a new client for the Base mainnet network
+    pub fn new_base_mainnet_client(
+        api_key: &str,
+        api_secret: &str,
+    ) -> Result<Self, ExternalMatchClientError> {
+        Self::new(api_key, api_secret, BASE_MAINNET_AUTH_BASE_URL, BASE_MAINNET_RELAYER_BASE_URL)
     }
 
     /// Create a new client for the Arbitrum One network


### PR DESCRIPTION
### Purpose
This PR adds Base client configs and an example using Base Sepolia to the rust SDK.

### Testing
- [x] All examples pass specifying a Base sepolia config
- [x] Base specific example passes