### PR TITLE
chore: Allow more permissive `alloy` versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renegade-sdk"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 description = "A Rust SDK for the Renegade protocol"
 homepage = "https://renegade.fi/"
@@ -86,8 +86,8 @@ serde = { version = "^1.0.197" }
 serde_json = "1.0.64"
 
 # === Ethereum === #
-alloy = { version = "1.0.1", features = ["essentials"] }
-alloy-rpc-types-eth = "1.0.1"
+alloy = { version = ">=0.12, <2.0", features = ["essentials"] }
+alloy-rpc-types-eth = { version = ">=0.12, <2.0" }
 
 # === Misc === #
 base64 = "0.22"

--- a/examples/order_book/order_book_depth.rs
+++ b/examples/order_book/order_book_depth.rs
@@ -1,11 +1,9 @@
 //! Example of getting the order book depth for a token
-use renegade_sdk::{example_utils::build_renegade_client, ExternalMatchClient};
+use renegade_sdk::example_utils::build_renegade_client;
 
 #[tokio::main]
 async fn main() -> Result<(), eyre::Error> {
     // Get the external match client
-    let api_key = std::env::var("EXTERNAL_MATCH_KEY").unwrap();
-    let api_secret = std::env::var("EXTERNAL_MATCH_SECRET").unwrap();
     let client = build_renegade_client(false /* use_base */).unwrap();
 
     // Fetch supported tokens


### PR DESCRIPTION
### Purpose
This PR allows more permissive alloy versions, given that we don't use the alloy functionality unique to `>0.1.0`.

### Testing
- [x] Tested on a local client that pinned `alloy=0.12.6`