### PR TITLE
chore: Widen allowable `reqwest` versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renegade-sdk"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 description = "A Rust SDK for the Renegade protocol"
 homepage = "https://renegade.fi/"
@@ -81,7 +81,7 @@ hmac = "0.12"
 sha2 = { version = "0.10", features = ["asm"] }
 
 # === Http === #
-reqwest = { version = "0.12.15", features = ["json"] }
+reqwest = { version = ">=0.12, <1.0", features = ["json"] }
 serde = { version = "^1.0.197" }
 serde_json = "1.0.64"
 


### PR DESCRIPTION
### Purpose
This PR allows a range of versions for the `reqwest` dependency to allow for different client pinned versions.

### Testing
- [x] Tested locally with clients pinned to a number of versions