### PR TITLE
external-match-client: Add all pairs book depth method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renegade-sdk"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 description = "A Rust SDK for the Renegade protocol"
 homepage = "https://renegade.fi/"
@@ -57,6 +57,11 @@ required-features = ["examples"]
 [[example]]
 name = "order_book_depth"
 path = "examples/order_book/order_book_depth.rs"
+required-features = ["examples"]
+
+[[example]]
+name = "all_pairs_depth"
+path = "examples/order_book/all_pairs_depth.rs"
 required-features = ["examples"]
 
 [[example]]

--- a/examples/order_book/all_pairs_depth.rs
+++ b/examples/order_book/all_pairs_depth.rs
@@ -1,0 +1,30 @@
+//! Example of getting the order book depth for all supported pairs
+use renegade_sdk::example_utils::build_renegade_client;
+
+#[tokio::main]
+async fn main() -> Result<(), eyre::Error> {
+    // Get the external match client
+    let client = build_renegade_client(false /* use_base */).unwrap();
+
+    // Get the order book depth for all pairs
+    println!("Fetching order book depth for all supported pairs...");
+    let all_pairs_depth = client.get_order_book_depth_all_pairs().await?;
+
+    println!("Found {} supported pairs:\n", all_pairs_depth.pairs.len());
+
+    // Print depth information for each pair
+    for (i, pair) in all_pairs_depth.pairs.iter().enumerate() {
+        println!("{}. Token Address: {}", i + 1, pair.address);
+        println!("   Current price: ${:.2}", pair.price);
+        println!("   Timestamp: {}", pair.timestamp);
+        println!("   Buy side:");
+        println!("     Total quantity: {}", pair.buy.total_quantity);
+        println!("     Total quantity (USD): ${:.2}", pair.buy.total_quantity_usd);
+        println!("   Sell side:");
+        println!("     Total quantity: {}", pair.sell.total_quantity);
+        println!("     Total quantity (USD): ${:.2}", pair.sell.total_quantity_usd);
+        println!();
+    }
+
+    Ok(())
+}

--- a/src/external_match_client/api_types/order_book.rs
+++ b/src/external_match_client/api_types/order_book.rs
@@ -4,13 +4,30 @@ use serde::{Deserialize, Serialize};
 /// Response for the GET /order_book/depth/:mint route
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetDepthByMintResponse {
+    /// The liquidity depth for the given mint
+    #[serde(flatten)]
+    pub depth: PriceAndDepth,
+}
+
+/// Response for the GET /order_book/depth route
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetDepthForAllPairsResponse {
+    /// The liquidity depth for all supported pairs
+    pub pairs: Vec<PriceAndDepth>,
+}
+
+/// The liquidity depth for a given pair
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PriceAndDepth {
+    /// The token address
+    pub address: String,
     /// The current price of the token in USD
     pub price: f64,
     /// The timestamp of the price
     pub timestamp: u64,
-    /// The buy side depth
+    /// The liquidity depth for the buy side
     pub buy: DepthSide,
-    /// The sell side depth
+    /// The liquidity depth for the sell side
     pub sell: DepthSide,
 }
 

--- a/src/external_match_client/client.rs
+++ b/src/external_match_client/client.rs
@@ -5,7 +5,10 @@ use reqwest::{
     StatusCode,
 };
 
-use crate::api_types::{order_book::GetDepthByMintResponse, ORDER_BOOK_DEPTH_ROUTE};
+use crate::api_types::{
+    order_book::{GetDepthByMintResponse, GetDepthForAllPairsResponse},
+    ORDER_BOOK_DEPTH_ROUTE,
+};
 #[allow(deprecated)]
 use crate::{
     api_types::{
@@ -224,6 +227,17 @@ impl ExternalMatchClient {
         let path = format!("{ORDER_BOOK_DEPTH_ROUTE}/{address}");
         let headers = self.get_headers()?;
         let resp = self.auth_http_client.get_with_headers(path.as_str(), headers).await?;
+
+        Ok(resp)
+    }
+
+    /// Get the order book depth for all supported tokens
+    pub async fn get_order_book_depth_all_pairs(
+        &self,
+    ) -> Result<GetDepthForAllPairsResponse, ExternalMatchClientError> {
+        let path = ORDER_BOOK_DEPTH_ROUTE;
+        let headers = self.get_headers()?;
+        let resp = self.auth_http_client.get_with_headers(path, headers).await?;
 
         Ok(resp)
     }


### PR DESCRIPTION
### Purpose
This PR adds a helper method and example for calling `/v0/order_book/depth` to fetch book depth for all supported pairs.

### Testing
- [ ] Testing against testnet