### PR TITLE
renegade-wallet-client: Add create wallet command and example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["renegade", "darkpool", "zk", "sdk"]
 license = "MIT"
 
 [[example]]
+
+# === External Match Examples === #
+
 name = "external_match"
 path = "examples/external_match/external_match.rs"
 required-features = ["examples"]
@@ -74,9 +77,16 @@ name = "malleable_match"
 path = "examples/external_match/malleable_match.rs"
 required-features = ["examples"]
 
+# === Wallet Examples === #
+
 [[example]]
 name = "generate_wallet"
 path = "examples/wallet/generate_wallet.rs"
+required-features = ["examples", "darkpool-client"]
+
+[[example]]
+name = "create_wallet"
+path = "examples/wallet/create_wallet.rs"
 required-features = ["examples", "darkpool-client"]
 
 [features]

--- a/examples/wallet/create_wallet.rs
+++ b/examples/wallet/create_wallet.rs
@@ -1,0 +1,30 @@
+//! Example of creating a wallet in the darkpool
+
+use alloy::signers::local::PrivateKeySigner;
+use renegade_sdk::client::RenegadeClient;
+use std::str::FromStr;
+
+/// The private key to use for the wallet
+const PKEY: &str = env!("PKEY");
+
+#[tokio::main]
+async fn main() -> Result<(), eyre::Error> {
+    // Read the private key from the environment variable
+    let private_key = PrivateKeySigner::from_str(PKEY)?;
+    let eth_address = private_key.address();
+    println!("Ethereum address: {:#x}", eth_address);
+    println!("Creating Renegade wallet client for Arbitrum Sepolia...");
+
+    // Create the Renegade client for Arbitrum Sepolia
+    let renegade_client = RenegadeClient::new_arbitrum_sepolia(&private_key)?;
+    println!("Wallet ID: {}", renegade_client.secrets.wallet_id);
+    println!("\nCreating wallet in darkpool...");
+
+    // Create the wallet in the darkpool
+    match renegade_client.create_wallet().await {
+        Ok(()) => println!("Successfully created wallet in darkpool!"),
+        Err(e) => println!("Failed to create wallet: {e}"),
+    }
+
+    Ok(())
+}

--- a/src/external_match_client/client.rs
+++ b/src/external_match_client/client.rs
@@ -5,9 +5,13 @@ use reqwest::{
     StatusCode,
 };
 
-use crate::api_types::{
-    order_book::{GetDepthByMintResponse, GetDepthForAllPairsResponse},
-    ORDER_BOOK_DEPTH_ROUTE,
+use crate::{
+    api_types::{
+        order_book::{GetDepthByMintResponse, GetDepthForAllPairsResponse},
+        ORDER_BOOK_DEPTH_ROUTE,
+    },
+    ARBITRUM_ONE_RELAYER_BASE_URL, ARBITRUM_SEPOLIA_RELAYER_BASE_URL,
+    BASE_MAINNET_RELAYER_BASE_URL, BASE_SEPOLIA_RELAYER_BASE_URL,
 };
 #[allow(deprecated)]
 use crate::{
@@ -43,14 +47,6 @@ const ARBITRUM_ONE_AUTH_BASE_URL: &str = "https://arbitrum-one.auth-server.reneg
 const BASE_SEPOLIA_AUTH_BASE_URL: &str = "https://base-sepolia.auth-server.renegade.fi";
 /// The Base mainnet auth server base URL
 const BASE_MAINNET_AUTH_BASE_URL: &str = "https://base-mainnet.auth-server.renegade.fi";
-/// The Arbitrum Sepolia relayer base URL
-const ARBITRUM_SEPOLIA_RELAYER_BASE_URL: &str = "https://arbitrum-sepolia.relayer.renegade.fi";
-/// The Arbitrum One relayer base URL
-const ARBITRUM_ONE_RELAYER_BASE_URL: &str = "https://arbitrum-one.relayer.renegade.fi";
-/// The Base Sepolia relayer base URL
-const BASE_SEPOLIA_RELAYER_BASE_URL: &str = "https://base-sepolia.relayer.renegade.fi";
-/// The Base mainnet relayer base URL
-const BASE_MAINNET_RELAYER_BASE_URL: &str = "https://base-mainnet.relayer.renegade.fi";
 
 // ----------
 // | Client |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,3 +20,17 @@ pub use renegade_wallet_client::*;
 
 #[cfg(feature = "examples")]
 pub mod example_utils;
+
+// -------------
+// | Constants |
+// -------------
+
+/// The Arbitrum Sepolia relayer base URL
+pub(crate) const ARBITRUM_SEPOLIA_RELAYER_BASE_URL: &str =
+    "https://arbitrum-sepolia.relayer.renegade.fi";
+/// The Arbitrum One relayer base URL
+pub(crate) const ARBITRUM_ONE_RELAYER_BASE_URL: &str = "https://arbitrum-one.relayer.renegade.fi";
+/// The Base Sepolia relayer base URL
+pub(crate) const BASE_SEPOLIA_RELAYER_BASE_URL: &str = "https://base-sepolia.relayer.renegade.fi";
+/// The Base mainnet relayer base URL
+pub(crate) const BASE_MAINNET_RELAYER_BASE_URL: &str = "https://base-mainnet.relayer.renegade.fi";

--- a/src/renegade_wallet_client/actions/create_wallet.rs
+++ b/src/renegade_wallet_client/actions/create_wallet.rs
@@ -1,0 +1,26 @@
+//! Create the wallet in the darkpool
+
+use renegade_api::{
+    http::wallet::{CreateWalletRequest, CreateWalletResponse, CREATE_WALLET_ROUTE},
+    types::ApiWallet,
+};
+
+use crate::{client::RenegadeClient, RenegadeClientError};
+
+impl RenegadeClient {
+    /// Create the wallet in the darkpool
+    ///
+    /// This method will ask a relayer to allocate the wallet's state in the
+    /// darkpool as an empty wallet derived from the user's key.
+    pub async fn create_wallet(&self) -> Result<(), RenegadeClientError> {
+        let wallet = self.secrets.generate_empty_wallet();
+        let api_wallet = ApiWallet::from(wallet);
+        let blinder_seed = self.secrets.blinder_seed.to_biguint();
+        let request = CreateWalletRequest { wallet: api_wallet, blinder_seed };
+
+        // TODO: Await the task ID for this response
+        let _response: CreateWalletResponse =
+            self.post_relayer(CREATE_WALLET_ROUTE, request).await?;
+        Ok(())
+    }
+}

--- a/src/renegade_wallet_client/actions/mod.rs
+++ b/src/renegade_wallet_client/actions/mod.rs
@@ -1,0 +1,3 @@
+//! Actions to update a Renegade wallet
+
+pub mod create_wallet;

--- a/src/renegade_wallet_client/client.rs
+++ b/src/renegade_wallet_client/client.rs
@@ -6,11 +6,22 @@ use renegade_common::types::wallet::{
         derive_blinder_seed, derive_share_seed, derive_wallet_id, derive_wallet_keychain,
     },
     keychain::KeyChain,
+    Wallet,
 };
 use renegade_constants::Scalar;
+use reqwest::header::HeaderMap;
+use serde::{de::DeserializeOwned, Serialize};
 use uuid::Uuid;
 
-use crate::RenegadeClientError;
+use crate::{
+    http::RelayerHttpClient, util::HmacKey as HttpHmacKey, RenegadeClientError,
+    ARBITRUM_ONE_RELAYER_BASE_URL, ARBITRUM_SEPOLIA_RELAYER_BASE_URL,
+    BASE_MAINNET_RELAYER_BASE_URL, BASE_SEPOLIA_RELAYER_BASE_URL,
+};
+
+// -------------
+// | Constants |
+// -------------
 
 /// The Arbitrum one chain ID
 const ARBITRUM_ONE_CHAIN_ID: u64 = 42161;
@@ -38,43 +49,120 @@ pub struct WalletSecrets {
     pub keychain: KeyChain,
 }
 
+impl WalletSecrets {
+    /// Generate an empty wallet with the given set of secrets
+    pub fn generate_empty_wallet(&self) -> Wallet {
+        Wallet::new_empty_wallet(
+            self.wallet_id,
+            self.blinder_seed,
+            self.share_seed,
+            self.keychain.clone(),
+        )
+    }
+}
+
 // -------------------
 // | Darkpool Client |
 // -------------------
 
 /// The Renegade wallet client
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RenegadeClient {
     /// The wallet secrets
     pub secrets: WalletSecrets,
+    /// The relayer HTTP client
+    pub relayer_client: RelayerHttpClient,
+}
+
+/// The client config
+#[derive(Debug, Clone)]
+pub struct RenegadeClientConfig {
+    /// The relayer base URL
+    pub relayer_base_url: String,
+    /// The chain ID
+    pub chain_id: u64,
+    /// The private key from which to derive the wallet
+    pub key: PrivateKeySigner,
 }
 
 impl RenegadeClient {
     /// Derive the wallet secrets from an ethereum private key
-    pub fn new(key: &PrivateKeySigner, chain_id: u64) -> Result<Self, RenegadeClientError> {
-        let secrets =
-            derive_wallet_from_key(key, chain_id).map_err(RenegadeClientError::setup_error)?;
-        Ok(Self { secrets })
+    pub fn new(config: RenegadeClientConfig) -> Result<Self, RenegadeClientError> {
+        let secrets = derive_wallet_from_key(&config.key, config.chain_id)
+            .map_err(RenegadeClientError::setup)?;
+        let hmac_key = secrets.keychain.secret_keys.symmetric_key;
+        let client = RelayerHttpClient::new(config.relayer_base_url, HttpHmacKey(hmac_key.0));
+
+        Ok(Self { secrets, relayer_client: client })
     }
 
     /// Create a new wallet on Arbitrum Sepolia
     pub fn new_arbitrum_sepolia(key: &PrivateKeySigner) -> Result<Self, RenegadeClientError> {
-        Self::new(key, ARBITRUM_SEPOLIA_CHAIN_ID)
+        let cfg = RenegadeClientConfig {
+            relayer_base_url: ARBITRUM_SEPOLIA_RELAYER_BASE_URL.to_string(),
+            chain_id: ARBITRUM_SEPOLIA_CHAIN_ID,
+            key: key.clone(),
+        };
+
+        Self::new(cfg)
     }
 
     /// Create a new wallet on Arbitrum One
     pub fn new_arbitrum_one(key: &PrivateKeySigner) -> Result<Self, RenegadeClientError> {
-        Self::new(key, ARBITRUM_ONE_CHAIN_ID)
+        let cfg = RenegadeClientConfig {
+            relayer_base_url: ARBITRUM_ONE_RELAYER_BASE_URL.to_string(),
+            chain_id: ARBITRUM_ONE_CHAIN_ID,
+            key: key.clone(),
+        };
+
+        Self::new(cfg)
     }
 
     /// Create a new wallet on Base Sepolia
     pub fn new_base_sepolia(key: &PrivateKeySigner) -> Result<Self, RenegadeClientError> {
-        Self::new(key, BASE_SEPOLIA_CHAIN_ID)
+        let cfg = RenegadeClientConfig {
+            relayer_base_url: BASE_SEPOLIA_RELAYER_BASE_URL.to_string(),
+            chain_id: BASE_SEPOLIA_CHAIN_ID,
+            key: key.clone(),
+        };
+
+        Self::new(cfg)
     }
 
     /// Create a new wallet on Base Mainnet
     pub fn new_base_mainnet(key: &PrivateKeySigner) -> Result<Self, RenegadeClientError> {
-        Self::new(key, BASE_MAINNET_CHAIN_ID)
+        let cfg = RenegadeClientConfig {
+            relayer_base_url: BASE_MAINNET_RELAYER_BASE_URL.to_string(),
+            chain_id: BASE_MAINNET_CHAIN_ID,
+            key: key.clone(),
+        };
+
+        Self::new(cfg)
+    }
+
+    /// Send a post request to the relayer
+    pub async fn post_relayer<Req: Serialize, Resp: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: Req,
+    ) -> Result<Resp, RenegadeClientError> {
+        // Send an HTTP request to the relayer
+        let resp = self
+            .relayer_client
+            .post_with_headers_raw(path, body, HeaderMap::new())
+            .await
+            .map_err(RenegadeClientError::request)?;
+        let body =
+            resp.text().await.unwrap_or_else(|_| "<failed to decode response body>".to_string());
+
+        // Attempt to decode the response body as the expected type
+        // Otherwise, emit the body as an error
+        let decoded: Result<Resp, _> = serde_json::from_str(&body);
+        if let Ok(decoded) = decoded {
+            Ok(decoded)
+        } else {
+            Err(RenegadeClientError::relayer(body))
+        }
     }
 }
 

--- a/src/renegade_wallet_client/mod.rs
+++ b/src/renegade_wallet_client/mod.rs
@@ -1,5 +1,6 @@
 //! The renegade wallet client manages Renegade wallet operations
 
+pub mod actions;
 pub mod client;
 
 /// The error type for the renegade wallet client
@@ -8,12 +9,30 @@ pub enum RenegadeClientError {
     /// An error setting up the wallet
     #[error("failed to setup wallet: {0}")]
     SetupError(String),
+    /// A relayer error
+    #[error("relayer error: {0}")]
+    RelayerError(String),
+    /// An error sending a request to the relayer
+    #[error("failed to send request to relayer: {0}")]
+    RequestError(String),
 }
 
 impl RenegadeClientError {
     /// Create a new setup error
     #[allow(clippy::needless_pass_by_value)]
-    pub fn setup_error<T: ToString>(msg: T) -> Self {
+    pub fn setup<T: ToString>(msg: T) -> Self {
         Self::SetupError(msg.to_string())
+    }
+
+    /// Create a new relayer error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn relayer<T: ToString>(msg: T) -> Self {
+        Self::RelayerError(msg.to_string())
+    }
+
+    /// Create a new request error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn request<T: ToString>(msg: T) -> Self {
+        Self::RequestError(msg.to_string())
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,7 +22,7 @@ pub const RENEGADE_SIG_EXPIRATION_HEADER_NAME: &str = "x-renegade-auth-expiratio
 type HmacSha256 = hmac::Hmac<sha2::Sha256>;
 /// A 32 byte HMAC key
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct HmacKey([u8; 32]);
+pub struct HmacKey(pub(crate) [u8; 32]);
 impl HmacKey {
     /// Create a new HMAC key from a base64 encoded string
     pub fn from_base64_string(s: &str) -> Result<Self, ExternalMatchClientError> {


### PR DESCRIPTION
### Purpose
This PR adds a create wallet command to the wallet SDK and an example to test with.

### Testing
- [x] Tested the example locally