### PR TITLE
renegade-wallet-client: actions: get-wallet: Add get wallet command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,11 @@ name = "create_wallet"
 path = "examples/wallet/create_wallet.rs"
 required-features = ["examples", "darkpool-client"]
 
+[[example]]
+name = "get_wallet"
+path = "examples/wallet/get_wallet.rs"
+required-features = ["examples", "darkpool-client"]
+
 [features]
 default = ["external-match-client", "darkpool-client"]
 external-match-client = []

--- a/examples/wallet/get_wallet.rs
+++ b/examples/wallet/get_wallet.rs
@@ -1,0 +1,39 @@
+//! Example of getting wallet state from the relayer
+
+use alloy::signers::local::PrivateKeySigner;
+use eyre::Result;
+use renegade_sdk::client::RenegadeClient;
+use renegade_utils::hex::biguint_to_hex_string;
+use std::str::FromStr;
+
+/// The private key to use for the wallet
+const PKEY: &str = env!("PKEY");
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Read the private key from the environment variable
+    let private_key = PrivateKeySigner::from_str(PKEY)?;
+    let eth_address = private_key.address();
+    println!("Ethereum address: {:#x}", eth_address);
+
+    // Create the Renegade client for Arbitrum Sepolia
+    let renegade_client = RenegadeClient::new_arbitrum_sepolia(&private_key)?;
+    println!("\nGetting wallet state from relayer...");
+
+    // Get the wallet state from the relayer
+    let wallet = renegade_client.get_wallet().await?;
+    println!("Wallet ID: {}", renegade_client.secrets.wallet_id);
+    println!("Wallet Orders:");
+    for order in wallet.orders {
+        let base_mint_hex = biguint_to_hex_string(&order.base_mint);
+        println!("\t - {}: {} {}", order.id, order.side, base_mint_hex)
+    }
+
+    println!("Wallet Balances:");
+    for balance in wallet.balances {
+        let balance_mint = biguint_to_hex_string(&balance.mint);
+        println!("\t - {}: {}", balance_mint, balance.amount)
+    }
+
+    Ok(())
+}

--- a/src/renegade_wallet_client/actions/get_wallet.rs
+++ b/src/renegade_wallet_client/actions/get_wallet.rs
@@ -1,0 +1,23 @@
+//! Gets the latest wallet state from the relayer
+
+use renegade_api::{
+    http::wallet::{GetWalletResponse, BACK_OF_QUEUE_WALLET_ROUTE},
+    types::ApiWallet,
+};
+
+use crate::{actions::construct_http_path, client::RenegadeClient, RenegadeClientError};
+
+/// Get the Renegade wallet state from the relayer
+///
+/// This action pulls the "back-of-queue" wallet for the client. So if there are
+/// any pending wallet tasks, this action will return the state assuming that
+/// the tasks complete
+impl RenegadeClient {
+    /// Get the latest wallet state from the relayer
+    pub async fn get_wallet(&self) -> Result<ApiWallet, RenegadeClientError> {
+        let id = self.secrets.wallet_id;
+        let path = construct_http_path!(BACK_OF_QUEUE_WALLET_ROUTE, "wallet_id" => id);
+        let response: GetWalletResponse = self.get_relayer(&path).await?;
+        Ok(response.wallet)
+    }
+}

--- a/src/renegade_wallet_client/actions/mod.rs
+++ b/src/renegade_wallet_client/actions/mod.rs
@@ -1,3 +1,17 @@
 //! Actions to update a Renegade wallet
 
 pub mod create_wallet;
+pub mod get_wallet;
+
+/// Constructs an HTTP path by replacing URL parameters with given values
+macro_rules! construct_http_path {
+    ($base_url:expr $(, $param:expr => $value:expr)*) => {{
+        let mut url = $base_url.to_string();
+        $(
+            let placeholder = format!(":{}", $param);
+            url = url.replace(&placeholder, &$value.to_string());
+        )*
+        url
+    }};
+}
+pub(crate) use construct_http_path;


### PR DESCRIPTION
### Purpose
This PR adds an action to get the back of queue wallet and return it to the user.

I also added an example for testing which prints wallet balances and orders.

### Testing
- [x] Tested the example