### PR TITLE
renegade-wallet-client: actions: create-order: Add create order command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,11 @@ name = "get_wallet"
 path = "examples/wallet/get_wallet.rs"
 required-features = ["examples", "darkpool-client"]
 
+[[example]]
+name = "place_order"
+path = "examples/wallet/place_order.rs"
+required-features = ["examples", "darkpool-client"]
+
 [features]
 default = ["external-match-client", "darkpool-client"]
 external-match-client = []

--- a/examples/wallet/place_order.rs
+++ b/examples/wallet/place_order.rs
@@ -1,0 +1,47 @@
+//! Example of placing an order in the wallet
+
+use alloy::signers::local::PrivateKeySigner;
+use num_bigint::BigUint;
+use renegade_api::types::{ApiOrder, ApiOrderType};
+use renegade_circuit_types::order::OrderSide;
+use renegade_sdk::{
+    actions::place_order::OrderBuilder, api_types::FixedPoint, client::RenegadeClient,
+};
+use renegade_utils::hex::biguint_from_hex_string;
+use std::str::FromStr;
+use uuid::Uuid;
+
+/// WETH address on arbitrum sepolia
+const WETH_ADDRESS: &str = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a";
+/// USDC address on arbitrum sepolia
+const USDC_ADDRESS: &str = "0xdf8d259c04020562717557f2b5a3cf28e92707d1";
+
+/// The private key to use for the wallet
+const PKEY: &str = env!("PKEY");
+
+#[tokio::main]
+async fn main() -> Result<(), eyre::Error> {
+    // Read the private key from the environment variable
+    let private_key = PrivateKeySigner::from_str(PKEY)?;
+    let eth_address = private_key.address();
+    println!("Ethereum address: {:#x}", eth_address);
+
+    // Create the Renegade client for Arbitrum Sepolia
+    let renegade_client = RenegadeClient::new_arbitrum_sepolia(&private_key)?;
+
+    // Create a sample order (selling WETH for USDC)
+    let order = OrderBuilder::new()
+        .with_base_mint(WETH_ADDRESS)?
+        .with_quote_mint(USDC_ADDRESS)?
+        .with_side(OrderSide::Sell)
+        .with_amount(1000u128)
+        .build()?;
+
+    // Place the order in the wallet
+    match renegade_client.place_order(order).await {
+        Ok(()) => println!("Successfully placed order in wallet!"),
+        Err(e) => println!("Failed to place order: {e}"),
+    }
+
+    Ok(())
+}

--- a/src/renegade_wallet_client/actions/get_wallet.rs
+++ b/src/renegade_wallet_client/actions/get_wallet.rs
@@ -4,6 +4,7 @@ use renegade_api::{
     http::wallet::{GetWalletResponse, BACK_OF_QUEUE_WALLET_ROUTE},
     types::ApiWallet,
 };
+use renegade_common::types::wallet::Wallet;
 
 use crate::{actions::construct_http_path, client::RenegadeClient, RenegadeClientError};
 
@@ -19,5 +20,12 @@ impl RenegadeClient {
         let path = construct_http_path!(BACK_OF_QUEUE_WALLET_ROUTE, "wallet_id" => id);
         let response: GetWalletResponse = self.get_relayer(&path).await?;
         Ok(response.wallet)
+    }
+
+    /// An internal helper to get the back of queue wallet as a
+    /// `renegade_common::Wallet`
+    pub(crate) async fn get_internal_wallet(&self) -> Result<Wallet, RenegadeClientError> {
+        let wallet = self.get_wallet().await?;
+        wallet.try_into().map_err(RenegadeClientError::conversion)
     }
 }

--- a/src/renegade_wallet_client/actions/mod.rs
+++ b/src/renegade_wallet_client/actions/mod.rs
@@ -2,6 +2,36 @@
 
 pub mod create_wallet;
 pub mod get_wallet;
+pub mod place_order;
+
+use renegade_api::http::wallet::WalletUpdateAuthorization;
+use renegade_common::types::wallet::Wallet;
+
+use crate::RenegadeClientError;
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Get wallet update authorization for a wallet after an update
+///
+/// Update auth is the signature of a commitment to the wallet's new state after
+/// it is reblinded.
+pub(crate) fn get_wallet_update_auth(
+    wallet: &mut Wallet,
+) -> Result<WalletUpdateAuthorization, RenegadeClientError> {
+    // First reblind the wallet
+    wallet.reblind_wallet();
+
+    // Sign a commitment to the wallet's new state
+    let commitment = wallet.get_wallet_share_commitment();
+    let sig = wallet.sign_commitment(commitment).map_err(RenegadeClientError::custom)?;
+    let statement_sig = sig.as_bytes().to_vec();
+
+    // Return the update auth
+    let update_auth = WalletUpdateAuthorization { statement_sig, new_root_key: None };
+    Ok(update_auth)
+}
 
 /// Constructs an HTTP path by replacing URL parameters with given values
 macro_rules! construct_http_path {

--- a/src/renegade_wallet_client/actions/place_order.rs
+++ b/src/renegade_wallet_client/actions/place_order.rs
@@ -1,0 +1,147 @@
+//! Places an order in the wallet
+
+use num_bigint::BigUint;
+use renegade_api::{
+    http::wallet::{CreateOrderRequest, CreateOrderResponse, WALLET_ORDERS_ROUTE},
+    types::{ApiOrder, ApiOrderType},
+};
+use renegade_circuit_types::{fixed_point::FixedPoint, max_price, order::OrderSide};
+use renegade_common::types::wallet::Order;
+use renegade_utils::hex::biguint_from_hex_string;
+use uuid::Uuid;
+
+use crate::{
+    actions::{construct_http_path, get_wallet_update_auth},
+    client::RenegadeClient,
+    RenegadeClientError,
+};
+
+impl RenegadeClient {
+    /// Place an order in the wallet
+    pub async fn place_order(&self, order: ApiOrder) -> Result<(), RenegadeClientError> {
+        // Add the order to the wallet
+        let mut wallet = self.get_internal_wallet().await?;
+        let internal_order =
+            Order::try_from(order.clone()).map_err(RenegadeClientError::conversion)?;
+        wallet.add_order(order.id, internal_order).map_err(RenegadeClientError::wallet)?;
+
+        // Update the wallet auth
+        let wallet_id = self.secrets.wallet_id;
+        let update_auth = get_wallet_update_auth(&mut wallet)?;
+        let request = CreateOrderRequest { update_auth, order };
+
+        let route = construct_http_path!(WALLET_ORDERS_ROUTE, "wallet_id" => wallet_id);
+        let _response: CreateOrderResponse = self.post_relayer(&route, request).await?;
+        Ok(())
+    }
+}
+
+// -----------------
+// | Order Builder |
+// -----------------
+
+/// Builder for creating ApiOrder instances
+#[derive(Debug, Default)]
+pub struct OrderBuilder {
+    /// The base token mint address.
+    base_mint: Option<BigUint>,
+    /// The quote token mint address.
+    quote_mint: Option<BigUint>,
+    /// The order side (Buy or Sell).
+    side: Option<OrderSide>,
+    /// The amount of the base token to trade.
+    amount: Option<u128>,
+    /// The worst case price the trader is willing to accept.
+    worst_case_price: Option<FixedPoint>,
+    /// The minimum amount that must be filled for the order to execute.
+    min_fill_size: Option<u128>,
+    /// Whether this order can be matched with external counterparties.
+    allow_external_matches: Option<bool>,
+}
+
+impl OrderBuilder {
+    /// Create a new OrderBuilder
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the base mint address
+    pub fn with_base_mint(mut self, base_mint: &str) -> Result<Self, RenegadeClientError> {
+        let hex_mint =
+            biguint_from_hex_string(base_mint).map_err(RenegadeClientError::invalid_order)?;
+        self.base_mint = Some(hex_mint);
+        Ok(self)
+    }
+
+    /// Set the quote mint address
+    pub fn with_quote_mint(mut self, quote_mint: &str) -> Result<Self, RenegadeClientError> {
+        let hex_mint =
+            biguint_from_hex_string(quote_mint).map_err(RenegadeClientError::invalid_order)?;
+        self.quote_mint = Some(hex_mint);
+        Ok(self)
+    }
+
+    /// Set the order side (Buy or Sell)
+    pub fn with_side(mut self, side: OrderSide) -> Self {
+        self.side = Some(side);
+        self
+    }
+
+    /// Set the order amount
+    pub fn with_amount(mut self, amount: u128) -> Self {
+        self.amount = Some(amount);
+        self
+    }
+
+    /// Set the worst case price
+    pub fn with_worst_case_price(mut self, price: f64) -> Self {
+        self.worst_case_price = Some(FixedPoint::from_f64_round_down(price));
+        self
+    }
+
+    /// Set the minimum fill size
+    pub fn with_min_fill_size(mut self, min_fill: u128) -> Self {
+        self.min_fill_size = Some(min_fill);
+        self
+    }
+
+    /// Set whether external matches are allowed
+    pub fn with_allow_external_matches(mut self, allow: bool) -> Self {
+        self.allow_external_matches = Some(allow);
+        self
+    }
+
+    /// Build the ApiOrder
+    pub fn build(self) -> Result<ApiOrder, RenegadeClientError> {
+        let id = Uuid::new_v4();
+        let worst_case_price = match (self.worst_case_price, self.side) {
+            (Some(price), _) => price,
+            (None, Some(OrderSide::Buy)) => max_price(),
+            (None, Some(OrderSide::Sell)) => FixedPoint::zero(),
+            _ => return Err(RenegadeClientError::invalid_order("side is required")),
+        };
+
+        macro_rules! unwrap_field {
+            ($field:ident) => {
+                self.$field.ok_or_else(|| {
+                    RenegadeClientError::invalid_order(format!(
+                        "{} is required for order",
+                        stringify!($field)
+                    ))
+                })?
+            };
+        }
+
+        Ok(ApiOrder {
+            id,
+            base_mint: unwrap_field!(base_mint),
+            quote_mint: unwrap_field!(quote_mint),
+            side: unwrap_field!(side),
+            amount: unwrap_field!(amount),
+            worst_case_price,
+            min_fill_size: self.min_fill_size.unwrap_or(0),
+            type_: ApiOrderType::Midpoint,
+            allow_external_matches: self.allow_external_matches.unwrap_or(true),
+        })
+    }
+}

--- a/src/renegade_wallet_client/mod.rs
+++ b/src/renegade_wallet_client/mod.rs
@@ -6,6 +6,15 @@ pub mod client;
 /// The error type for the renegade wallet client
 #[derive(Debug, thiserror::Error)]
 pub enum RenegadeClientError {
+    /// An error converting from an API type to an internal type
+    #[error("failed to convert from API type to internal type: {0}")]
+    ConversionError(String),
+    /// Custom error
+    #[error("error: {0}")]
+    CustomError(String),
+    /// An invalid order was provided
+    #[error("invalid order: {0}")]
+    InvalidOrder(String),
     /// An error setting up the wallet
     #[error("failed to setup wallet: {0}")]
     SetupError(String),
@@ -15,9 +24,30 @@ pub enum RenegadeClientError {
     /// An error sending a request to the relayer
     #[error("failed to send request to relayer: {0}")]
     RequestError(String),
+    /// A wallet error
+    #[error("wallet error: {0}")]
+    Wallet(String),
 }
 
 impl RenegadeClientError {
+    /// Create a new custom error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn custom<T: ToString>(msg: T) -> Self {
+        Self::CustomError(msg.to_string())
+    }
+
+    /// Create a new conversion error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn conversion<T: ToString>(msg: T) -> Self {
+        Self::ConversionError(msg.to_string())
+    }
+
+    /// Create a new invalid order error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn invalid_order<T: ToString>(msg: T) -> Self {
+        Self::InvalidOrder(msg.to_string())
+    }
+
     /// Create a new setup error
     #[allow(clippy::needless_pass_by_value)]
     pub fn setup<T: ToString>(msg: T) -> Self {
@@ -34,5 +64,11 @@ impl RenegadeClientError {
     #[allow(clippy::needless_pass_by_value)]
     pub fn request<T: ToString>(msg: T) -> Self {
         Self::RequestError(msg.to_string())
+    }
+
+    /// Create a new wallet error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn wallet<T: ToString>(msg: T) -> Self {
+        Self::Wallet(msg.to_string())
     }
 }


### PR DESCRIPTION
### Purpose
This PR adds a `create_order` method to the wallet client as well as an `OrderBuilder` struct and an example creating a WETH sell order.

### Testing
- [x] Example runs as expected