### PR TITLE
renegade-wallet-client: actions: cancel-order: Add order cancellation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,11 @@ name = "place_order"
 path = "examples/wallet/place_order.rs"
 required-features = ["examples", "darkpool-client"]
 
+[[example]]
+name = "cancel_order"
+path = "examples/wallet/cancel_order.rs"
+required-features = ["examples", "darkpool-client"]
+
 [features]
 default = ["external-match-client", "darkpool-client"]
 external-match-client = []

--- a/examples/wallet/cancel_order.rs
+++ b/examples/wallet/cancel_order.rs
@@ -1,0 +1,37 @@
+//! Example of canceling an order in the wallet
+
+use alloy::signers::local::PrivateKeySigner;
+use renegade_sdk::client::RenegadeClient;
+use std::str::FromStr;
+use uuid::Uuid;
+
+/// The private key to use for the wallet
+const PKEY: &str = env!("PKEY");
+
+#[tokio::main]
+async fn main() -> Result<(), eyre::Error> {
+    // Read the private key from the environment variable
+    let private_key = PrivateKeySigner::from_str(PKEY)?;
+    let eth_address = private_key.address();
+    println!("Ethereum address: {:#x}", eth_address);
+
+    // Create the Renegade client for Arbitrum Sepolia
+    let renegade_client = RenegadeClient::new_arbitrum_sepolia(&private_key)?;
+
+    // Get the wallet to see existing orders
+    let wallet = renegade_client.get_wallet().await?;
+    if wallet.orders.is_empty() {
+        println!("No orders found in wallet to cancel");
+        return Ok(());
+    }
+
+    // Get the first order ID from the wallet
+    let order_id = wallet.orders[0].id;
+    println!("Canceling order with ID: {}", order_id);
+    match renegade_client.cancel_order(order_id).await {
+        Ok(()) => println!("Successfully canceled order!"),
+        Err(e) => println!("Failed to cancel order: {e}"),
+    }
+
+    Ok(())
+}

--- a/src/renegade_wallet_client/actions/cancel_order.rs
+++ b/src/renegade_wallet_client/actions/cancel_order.rs
@@ -1,0 +1,31 @@
+//! Cancels an order in the wallet
+
+use renegade_api::http::wallet::{CancelOrderRequest, CancelOrderResponse, CANCEL_ORDER_ROUTE};
+use uuid::Uuid;
+
+use crate::{
+    actions::{construct_http_path, prepare_wallet_update},
+    client::RenegadeClient,
+    RenegadeClientError,
+};
+
+impl RenegadeClient {
+    /// Cancels an order in the wallet
+    pub async fn cancel_order(&self, order_id: Uuid) -> Result<(), RenegadeClientError> {
+        let mut wallet = self.get_internal_wallet().await?;
+        if !wallet.contains_order(&order_id) {
+            return Err(RenegadeClientError::wallet(format!(
+                "Order {order_id} not found in wallet"
+            )));
+        }
+
+        wallet.remove_order(&order_id).unwrap();
+        let update_auth = prepare_wallet_update(&mut wallet)?;
+
+        // Send the request
+        let route = construct_http_path!(CANCEL_ORDER_ROUTE, "wallet_id" => self.secrets.wallet_id, "order_id" => order_id);
+        let request = CancelOrderRequest { update_auth };
+        let _response: CancelOrderResponse = self.post_relayer(&route, request).await?;
+        Ok(())
+    }
+}

--- a/src/renegade_wallet_client/actions/mod.rs
+++ b/src/renegade_wallet_client/actions/mod.rs
@@ -1,5 +1,6 @@
 //! Actions to update a Renegade wallet
 
+pub mod cancel_order;
 pub mod create_wallet;
 pub mod get_wallet;
 pub mod place_order;
@@ -17,7 +18,7 @@ use crate::RenegadeClientError;
 ///
 /// Update auth is the signature of a commitment to the wallet's new state after
 /// it is reblinded.
-pub(crate) fn get_wallet_update_auth(
+pub(crate) fn prepare_wallet_update(
     wallet: &mut Wallet,
 ) -> Result<WalletUpdateAuthorization, RenegadeClientError> {
     // First reblind the wallet

--- a/src/renegade_wallet_client/actions/place_order.rs
+++ b/src/renegade_wallet_client/actions/place_order.rs
@@ -11,7 +11,7 @@ use renegade_utils::hex::biguint_from_hex_string;
 use uuid::Uuid;
 
 use crate::{
-    actions::{construct_http_path, get_wallet_update_auth},
+    actions::{construct_http_path, prepare_wallet_update},
     client::RenegadeClient,
     RenegadeClientError,
 };
@@ -27,7 +27,7 @@ impl RenegadeClient {
 
         // Update the wallet auth
         let wallet_id = self.secrets.wallet_id;
-        let update_auth = get_wallet_update_auth(&mut wallet)?;
+        let update_auth = prepare_wallet_update(&mut wallet)?;
         let request = CreateOrderRequest { update_auth, order };
 
         let route = construct_http_path!(WALLET_ORDERS_ROUTE, "wallet_id" => wallet_id);


### PR DESCRIPTION
### Purpose
This PR adds a cancel order command to the darkpool and an example using this command.

### Testing
- [x] Example works as intended.