### PR TITLE
external_match_client: add exact amount parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,11 @@ path = "examples/external_match/in_kind_gas_sponsorship.rs"
 required-features = ["examples"]
 
 [[example]]
+name = "exact_quote_output"
+path = "examples/external_match/exact_quote_output.rs"
+required-features = ["examples"]
+
+[[example]]
 name = "supported_tokens"
 path = "examples/order_book/supported_tokens.rs"
 required-features = ["examples"]

--- a/src/external_match_client/api_types/order_types.rs
+++ b/src/external_match_client/api_types/order_types.rs
@@ -36,6 +36,12 @@ pub struct ExternalOrder {
     /// The quote amount of the order
     #[serde(default)]
     pub quote_amount: Amount,
+    /// The exact base amount to output from the order
+    #[serde(default)]
+    pub exact_base_output: Amount,
+    /// The exact quote amount to output from the order
+    #[serde(default)]
+    pub exact_quote_output: Amount,
     /// The minimum fill size for the order
     #[serde(default)]
     pub min_fill_size: Amount,


### PR DESCRIPTION
### Purpose
This PR adds exact amount parameters to the ExternalOrder struct.

### Testing
- [ ] Tested locally against testnet using example