### PR TITLE
renegade_wallet_client: actions: add get_task_queue action

### DIFF
--- a/src/renegade_wallet_client/actions/get_task_queue.rs
+++ b/src/renegade_wallet_client/actions/get_task_queue.rs
@@ -1,0 +1,18 @@
+//! Fetches the wallet's current task queue from the relayer
+
+use renegade_api::http::task::{ApiTaskStatus, TaskQueueListResponse, GET_TASK_QUEUE_ROUTE};
+
+use crate::{actions::construct_http_path, client::RenegadeClient, RenegadeClientError};
+
+impl RenegadeClient {
+    /// Fetches the list of tasks currently enqueued for the wallet by the
+    /// relayer.
+    ///
+    /// This includes the currently-running task, if there is one.
+    pub async fn get_task_queue(&self) -> Result<Vec<ApiTaskStatus>, RenegadeClientError> {
+        let wallet_id = self.secrets.wallet_id;
+        let path = construct_http_path!(GET_TASK_QUEUE_ROUTE, "wallet_id" => wallet_id);
+        let response: TaskQueueListResponse = self.get_relayer(&path).await?;
+        Ok(response.tasks)
+    }
+}

--- a/src/renegade_wallet_client/actions/mod.rs
+++ b/src/renegade_wallet_client/actions/mod.rs
@@ -5,6 +5,7 @@ pub mod create_wallet;
 pub mod deposit;
 pub mod get_balance_by_mint;
 pub mod get_order;
+pub mod get_task_queue;
 pub mod get_wallet;
 pub mod place_order;
 pub mod withdraw;


### PR DESCRIPTION
In this PR, we implement the `get_task_queue` action for fetching the current enqueued tasks for the wallet.

### Testing
- [x] Test against testnet relayer