### PR TITLE
renegade_wallet_client: websocket: reconnect to websocket upon closure

### DIFF
--- a/src/renegade_wallet_client/websocket/task_waiter.rs
+++ b/src/renegade_wallet_client/websocket/task_waiter.rs
@@ -67,8 +67,8 @@ impl TaskWaiter {
         let timeout = tokio::time::timeout(TASK_TIMEOUT, notification_rx.recv());
         let notification = timeout
             .await
-            .map_err(|_| RenegadeClientError::task("Task timed out"))?
-            .ok_or_else(|| RenegadeClientError::task("Task waiter closed"))?;
+            .map_err(|_| RenegadeClientError::task(format!("Task {task_id} timed out")))?
+            .ok_or_else(|| RenegadeClientError::task(format!("Task {task_id} waiter closed")))?;
 
         notification.into_result()
     }


### PR DESCRIPTION
In this PR, we introduce reconnection logic to the `RenegadeWebsocketClient`. Previously, if the websocket connection was closed abruptly, the client would simply continue to attempt sending messages over the write end of the websocket stream and fail with `failed to send websocket message`. In fact, even in the case of graceful closure, the thread running the `handle_ws_connection` loop would simply join and the subscription channel's buffer would fill up with unhandled subscription requests.

Now, we wrap `handle_ws_connection` with the `ws_reconnection_loop` and propagate errors sending websocket messages, as they are indicative of websocket closures. When this (or graceful closure) occurs, a new websocket connection is established.

Additionally, we re-subscribe to all pending tasks when we re-establish the connection.

### Testing
- [x] Test locally w/ mocked websocket closure