### PR TITLE
renegade_wallet_client: task history action + fallback in task waiter

### DIFF
--- a/src/external_match_client/client.rs
+++ b/src/external_match_client/client.rs
@@ -10,8 +10,10 @@ use crate::{
         order_book::{GetDepthByMintResponse, GetDepthForAllPairsResponse},
         ORDER_BOOK_DEPTH_ROUTE,
     },
-    ARBITRUM_ONE_RELAYER_BASE_URL, ARBITRUM_SEPOLIA_RELAYER_BASE_URL,
-    BASE_MAINNET_RELAYER_BASE_URL, BASE_SEPOLIA_RELAYER_BASE_URL,
+    config::{
+        ARBITRUM_ONE_RELAYER_BASE_URL, ARBITRUM_SEPOLIA_RELAYER_BASE_URL,
+        BASE_MAINNET_RELAYER_BASE_URL, BASE_SEPOLIA_RELAYER_BASE_URL,
+    },
 };
 #[allow(deprecated)]
 use crate::{

--- a/src/external_match_client/error.rs
+++ b/src/external_match_client/error.rs
@@ -2,6 +2,8 @@
 
 use reqwest::StatusCode;
 
+use crate::http::RelayerHttpClientError;
+
 /// An error that can occur when requesting an external match
 #[derive(Debug, thiserror::Error)]
 pub enum ExternalMatchClientError {
@@ -55,6 +57,12 @@ impl ExternalMatchClientError {
 
 impl From<reqwest::Error> for ExternalMatchClientError {
     fn from(err: reqwest::Error) -> Self {
+        Self::Http(None, err.to_string())
+    }
+}
+
+impl From<RelayerHttpClientError> for ExternalMatchClientError {
+    fn from(err: RelayerHttpClientError) -> Self {
         Self::Http(None, err.to_string())
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -2,7 +2,7 @@
 
 use crate::util::{self, HmacKey};
 
-use reqwest::{header::HeaderMap, Client, Error};
+use reqwest::{header::HeaderMap, Client};
 use serde::{de::DeserializeOwned, Serialize};
 use std::time::Duration;
 
@@ -11,6 +11,25 @@ const REQUEST_SIGNATURE_DURATION: Duration = Duration::from_secs(10);
 
 /// The header name for the SDK version
 const SDK_VERSION_HEADER: &str = "x-renegade-sdk-version";
+
+/// The error message when a response body cannot be decoded
+const RESPONSE_BODY_DECODE_ERROR: &str = "<failed to decode response body>";
+
+#[derive(Debug, thiserror::Error)]
+pub enum RelayerHttpClientError {
+    /// An error making an HTTP request
+    #[error("HTTP error: {0}")]
+    Http(reqwest::Error),
+    /// An error in de/serialization
+    #[error("serde error: {0}")]
+    Serde(String),
+}
+
+impl From<reqwest::Error> for RelayerHttpClientError {
+    fn from(err: reqwest::Error) -> Self {
+        Self::Http(err)
+    }
+}
 
 /// An HTTP client for connecting to the relayer
 #[derive(Clone)]
@@ -39,12 +58,12 @@ impl RelayerHttpClient {
         &self,
         path: &str,
         body: Req,
-    ) -> Result<Resp, Error> {
+    ) -> Result<Resp, RelayerHttpClientError> {
         self.post_with_headers(path, body, HeaderMap::new()).await
     }
 
     /// Send a GET request to the relayer
-    pub async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T, Error> {
+    pub async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T, RelayerHttpClientError> {
         self.get_with_headers(path, HeaderMap::new()).await
     }
 
@@ -54,9 +73,18 @@ impl RelayerHttpClient {
         path: &str,
         body: Req,
         custom_headers: HeaderMap,
-    ) -> Result<Resp, Error> {
+    ) -> Result<Resp, RelayerHttpClientError> {
         let response = self.post_with_headers_raw(path, body, custom_headers).await?;
-        response.json().await
+        let body = response.text().await.unwrap_or_else(|_| RESPONSE_BODY_DECODE_ERROR.to_string());
+
+        // Attempt to decode the response body as the expected type
+        // Otherwise, emit the body as an error
+        let decoded: Result<Resp, _> = serde_json::from_str(&body);
+        if let Ok(decoded) = decoded {
+            Ok(decoded)
+        } else {
+            Err(RelayerHttpClientError::Serde(body))
+        }
     }
 
     /// Send a GET request with custom headers to the relayer
@@ -64,9 +92,18 @@ impl RelayerHttpClient {
         &self,
         path: &str,
         custom_headers: HeaderMap,
-    ) -> Result<T, Error> {
+    ) -> Result<T, RelayerHttpClientError> {
         let response = self.get_with_headers_raw(path, custom_headers).await?;
-        response.json().await
+        let body = response.text().await.unwrap_or_else(|_| RESPONSE_BODY_DECODE_ERROR.to_string());
+
+        // Attempt to decode the response body as the expected type
+        // Otherwise, emit the body as an error
+        let decoded: Result<T, _> = serde_json::from_str(&body);
+        if let Ok(decoded) = decoded {
+            Ok(decoded)
+        } else {
+            Err(RelayerHttpClientError::Serde(body))
+        }
     }
 
     /// Send a POST request with custom headers to the relayer and return raw
@@ -76,7 +113,7 @@ impl RelayerHttpClient {
         path: &str,
         body: Req,
         mut custom_headers: HeaderMap,
-    ) -> Result<reqwest::Response, Error> {
+    ) -> Result<reqwest::Response, RelayerHttpClientError> {
         let url = format!("{}{}", self.base_url, path);
         let body_bytes = serde_json::to_vec(&body).unwrap();
         self.add_headers(path, &mut custom_headers, &body_bytes);
@@ -91,7 +128,7 @@ impl RelayerHttpClient {
         &self,
         path: &str,
         mut custom_headers: HeaderMap,
-    ) -> Result<reqwest::Response, Error> {
+    ) -> Result<reqwest::Response, RelayerHttpClientError> {
         let url = format!("{}{}", self.base_url, path);
         self.add_headers(path, &mut custom_headers, &[]);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,17 +20,3 @@ pub use renegade_wallet_client::*;
 
 #[cfg(feature = "examples")]
 pub mod example_utils;
-
-// -------------
-// | Constants |
-// -------------
-
-/// The Arbitrum Sepolia relayer base URL
-pub(crate) const ARBITRUM_SEPOLIA_RELAYER_BASE_URL: &str =
-    "https://arbitrum-sepolia.relayer.renegade.fi";
-/// The Arbitrum One relayer base URL
-pub(crate) const ARBITRUM_ONE_RELAYER_BASE_URL: &str = "https://arbitrum-one.relayer.renegade.fi";
-/// The Base Sepolia relayer base URL
-pub(crate) const BASE_SEPOLIA_RELAYER_BASE_URL: &str = "https://base-sepolia.relayer.renegade.fi";
-/// The Base mainnet relayer base URL
-pub(crate) const BASE_MAINNET_RELAYER_BASE_URL: &str = "https://base-mainnet.relayer.renegade.fi";

--- a/src/renegade_wallet_client/actions/cancel_order.rs
+++ b/src/renegade_wallet_client/actions/cancel_order.rs
@@ -26,7 +26,7 @@ impl RenegadeClient {
         // Send the request
         let route = construct_http_path!(CANCEL_ORDER_ROUTE, "wallet_id" => self.secrets.wallet_id, "order_id" => order_id);
         let request = CancelOrderRequest { update_auth };
-        let response: CancelOrderResponse = self.post_relayer(&route, request).await?;
+        let response: CancelOrderResponse = self.relayer_client.post(&route, request).await?;
 
         // Create a task waiter for the task
         let task_id = response.task_id;

--- a/src/renegade_wallet_client/actions/create_wallet.rs
+++ b/src/renegade_wallet_client/actions/create_wallet.rs
@@ -19,7 +19,7 @@ impl RenegadeClient {
         let request = CreateWalletRequest { wallet: api_wallet, blinder_seed };
 
         let response: CreateWalletResponse =
-            self.post_relayer(CREATE_WALLET_ROUTE, request).await?;
+            self.relayer_client.post(CREATE_WALLET_ROUTE, request).await?;
 
         // Create a task waiter for the task
         let task_id = response.task_id;

--- a/src/renegade_wallet_client/actions/deposit.rs
+++ b/src/renegade_wallet_client/actions/deposit.rs
@@ -57,7 +57,7 @@ impl RenegadeClient {
             permit_deadline: transfer_auth.permit_deadline,
             permit_signature: transfer_auth.permit_signature,
         };
-        let response: DepositBalanceResponse = self.post_relayer(&route, request).await?;
+        let response: DepositBalanceResponse = self.relayer_client.post(&route, request).await?;
 
         // Create a task waiter for the task
         let task_id = response.task_id;

--- a/src/renegade_wallet_client/actions/get_balance_by_mint.rs
+++ b/src/renegade_wallet_client/actions/get_balance_by_mint.rs
@@ -17,7 +17,7 @@ impl RenegadeClient {
         let wallet_id = self.secrets.wallet_id;
         let mint_str = mint.to_string();
         let path = construct_http_path!(GET_BALANCE_BY_MINT_ROUTE, "wallet_id" => wallet_id, "mint" => mint_str);
-        let response: GetBalanceByMintResponse = self.get_relayer(&path).await?;
+        let response: GetBalanceByMintResponse = self.relayer_client.get(&path).await?;
         Ok(response.balance)
     }
 }

--- a/src/renegade_wallet_client/actions/get_order.rs
+++ b/src/renegade_wallet_client/actions/get_order.rs
@@ -18,7 +18,7 @@ impl RenegadeClient {
     pub async fn get_order(&self, order_id: Uuid) -> Result<ApiOrder, RenegadeClientError> {
         let wallet_id = self.secrets.wallet_id;
         let path = construct_http_path!(GET_ORDER_BY_ID_ROUTE, "wallet_id" => wallet_id, "order_id" => order_id);
-        let response: GetOrderByIdResponse = self.get_relayer(&path).await?;
+        let response: GetOrderByIdResponse = self.relayer_client.get(&path).await?;
         Ok(response.order)
     }
 }

--- a/src/renegade_wallet_client/actions/get_task_history.rs
+++ b/src/renegade_wallet_client/actions/get_task_history.rs
@@ -1,0 +1,30 @@
+//! Gets the wallet's task history from the historical state engine
+
+use renegade_api::{
+    http::task_history::{GetTaskHistoryResponse, TASK_HISTORY_ROUTE},
+    types::ApiHistoricalTask,
+};
+use renegade_common::types::wallet::WalletIdentifier;
+
+use crate::{
+    actions::construct_http_path, client::RenegadeClient, http::RelayerHttpClient,
+    RenegadeClientError,
+};
+
+impl RenegadeClient {
+    /// Get the wallet's task history from the historical state engine
+    pub async fn get_task_history(&self) -> Result<Vec<ApiHistoricalTask>, RenegadeClientError> {
+        get_task_history(&self.historical_state_client, self.secrets.wallet_id).await
+    }
+}
+
+/// Request task history for the given wallet on the given HTTP client
+// TODO: Implement response pagination
+pub async fn get_task_history(
+    client: &RelayerHttpClient,
+    wallet_id: WalletIdentifier,
+) -> Result<Vec<ApiHistoricalTask>, RenegadeClientError> {
+    let path = construct_http_path!(TASK_HISTORY_ROUTE, "wallet_id" => wallet_id);
+    let response: GetTaskHistoryResponse = client.get(&path).await?;
+    Ok(response.tasks)
+}

--- a/src/renegade_wallet_client/actions/get_task_queue.rs
+++ b/src/renegade_wallet_client/actions/get_task_queue.rs
@@ -12,7 +12,7 @@ impl RenegadeClient {
     pub async fn get_task_queue(&self) -> Result<Vec<ApiTaskStatus>, RenegadeClientError> {
         let wallet_id = self.secrets.wallet_id;
         let path = construct_http_path!(GET_TASK_QUEUE_ROUTE, "wallet_id" => wallet_id);
-        let response: TaskQueueListResponse = self.get_relayer(&path).await?;
+        let response: TaskQueueListResponse = self.relayer_client.get(&path).await?;
         Ok(response.tasks)
     }
 }

--- a/src/renegade_wallet_client/actions/get_wallet.rs
+++ b/src/renegade_wallet_client/actions/get_wallet.rs
@@ -18,7 +18,7 @@ impl RenegadeClient {
     pub async fn get_wallet(&self) -> Result<ApiWallet, RenegadeClientError> {
         let id = self.secrets.wallet_id;
         let path = construct_http_path!(BACK_OF_QUEUE_WALLET_ROUTE, "wallet_id" => id);
-        let response: GetWalletResponse = self.get_relayer(&path).await?;
+        let response: GetWalletResponse = self.relayer_client.get(&path).await?;
         Ok(response.wallet)
     }
 

--- a/src/renegade_wallet_client/actions/lookup_wallet.rs
+++ b/src/renegade_wallet_client/actions/lookup_wallet.rs
@@ -24,7 +24,8 @@ impl RenegadeClient {
         let request =
             FindWalletRequest { wallet_id, blinder_seed, secret_share_seed, private_keychain };
 
-        let response: FindWalletResponse = self.post_relayer(FIND_WALLET_ROUTE, request).await?;
+        let response: FindWalletResponse =
+            self.relayer_client.post(FIND_WALLET_ROUTE, request).await?;
 
         let task_id = response.task_id;
         Ok(self.get_task_waiter(task_id))

--- a/src/renegade_wallet_client/actions/mod.rs
+++ b/src/renegade_wallet_client/actions/mod.rs
@@ -5,6 +5,7 @@ pub mod create_wallet;
 pub mod deposit;
 pub mod get_balance_by_mint;
 pub mod get_order;
+pub mod get_task_history;
 pub mod get_task_queue;
 pub mod get_wallet;
 pub mod lookup_wallet;

--- a/src/renegade_wallet_client/actions/place_order.rs
+++ b/src/renegade_wallet_client/actions/place_order.rs
@@ -32,7 +32,7 @@ impl RenegadeClient {
         let request = CreateOrderRequest { update_auth, order };
 
         let route = construct_http_path!(WALLET_ORDERS_ROUTE, "wallet_id" => wallet_id);
-        let response: CreateOrderResponse = self.post_relayer(&route, request).await?;
+        let response: CreateOrderResponse = self.relayer_client.post(&route, request).await?;
 
         // Create a task waiter for the task
         let task_id = response.task_id;

--- a/src/renegade_wallet_client/actions/withdraw.rs
+++ b/src/renegade_wallet_client/actions/withdraw.rs
@@ -62,7 +62,7 @@ impl RenegadeClient {
             update_auth,
             external_transfer_sig: transfer_auth.external_transfer_signature,
         };
-        let response: WithdrawBalanceResponse = self.post_relayer(&route, request).await?;
+        let response: WithdrawBalanceResponse = self.relayer_client.post(&route, request).await?;
 
         // Create a task waiter for the task
         let task_id = response.task_id;
@@ -73,7 +73,9 @@ impl RenegadeClient {
     async fn enqueue_pay_fees(&self) -> Result<(), RenegadeClientError> {
         let wallet_id = self.secrets.wallet_id;
         let route = construct_http_path!(PAY_FEES_ROUTE, "wallet_id" => wallet_id);
-        let _response: PayFeesResponse = self.post_relayer(&route, EmptyRequestResponse {}).await?;
+        let _response: PayFeesResponse =
+            self.relayer_client.post(&route, EmptyRequestResponse {}).await?;
+
         Ok(())
     }
 

--- a/src/renegade_wallet_client/client.rs
+++ b/src/renegade_wallet_client/client.rs
@@ -11,8 +11,6 @@ use renegade_common::types::wallet::{
     Wallet,
 };
 use renegade_constants::Scalar;
-use reqwest::header::HeaderMap;
-use serde::{de::DeserializeOwned, Serialize};
 use uuid::Uuid;
 
 use crate::websocket::TaskWaiter;
@@ -75,6 +73,11 @@ pub struct RenegadeClient {
     pub secrets: WalletSecrets,
     /// The relayer HTTP client
     pub relayer_client: RelayerHttpClient,
+    /// The historical state HTTP client.
+    ///
+    /// Also a `RelayerHttpClient` as it mirrors the relayer's historical state
+    /// API.
+    pub historical_state_client: RelayerHttpClient,
     /// The websocket client
     pub websocket_client: RenegadeWebsocketClient,
 }
@@ -85,11 +88,18 @@ impl RenegadeClient {
         let secrets = derive_wallet_from_key(&config.key, config.chain_id)
             .map_err(RenegadeClientError::setup)?;
         let hmac_key = secrets.keychain.secret_keys.symmetric_key;
-        let client =
+
+        let relayer_client =
             RelayerHttpClient::new(config.relayer_base_url.clone(), HttpHmacKey(hmac_key.0));
+
+        let historical_state_client = RelayerHttpClient::new(
+            config.historical_state_base_url.clone(),
+            HttpHmacKey(hmac_key.0),
+        );
+
         let websocket_client = RenegadeWebsocketClient::new(&config);
 
-        Ok(Self { config, secrets, relayer_client: client, websocket_client })
+        Ok(Self { config, secrets, relayer_client, historical_state_client, websocket_client })
     }
 
     /// Create a new wallet on Arbitrum Sepolia
@@ -126,57 +136,6 @@ impl RenegadeClient {
     /// Get a task waiter for a task
     pub fn get_task_waiter(&self, task_id: TaskIdentifier) -> TaskWaiter {
         TaskWaiter::new(task_id, self.websocket_client.clone())
-    }
-
-    // --------------
-    // | HTTP Utils |
-    // --------------
-
-    /// Send a get request to the relayer
-    pub async fn get_relayer<Resp: DeserializeOwned>(
-        &self,
-        path: &str,
-    ) -> Result<Resp, RenegadeClientError> {
-        let headers = HeaderMap::new();
-        let resp = self
-            .relayer_client
-            .get_with_headers_raw(path, headers)
-            .await
-            .map_err(RenegadeClientError::request)?;
-        let body = resp.text().await.unwrap_or_else(|_| RESPONSE_BODY_DECODE_ERROR.to_string());
-
-        // Try decoding the response body as the expected type
-        let decoded: Result<Resp, _> = serde_json::from_str(&body);
-        if let Ok(decoded) = decoded {
-            Ok(decoded)
-        } else {
-            Err(RenegadeClientError::relayer(body))
-        }
-    }
-
-    /// Send a post request to the relayer
-    pub async fn post_relayer<Req: Serialize, Resp: DeserializeOwned>(
-        &self,
-        path: &str,
-        body: Req,
-    ) -> Result<Resp, RenegadeClientError> {
-        // Send an HTTP request to the relayer
-        let headers = HeaderMap::new();
-        let resp = self
-            .relayer_client
-            .post_with_headers_raw(path, body, headers)
-            .await
-            .map_err(RenegadeClientError::request)?;
-        let body = resp.text().await.unwrap_or_else(|_| RESPONSE_BODY_DECODE_ERROR.to_string());
-
-        // Attempt to decode the response body as the expected type
-        // Otherwise, emit the body as an error
-        let decoded: Result<Resp, _> = serde_json::from_str(&body);
-        if let Ok(decoded) = decoded {
-            Ok(decoded)
-        } else {
-            Err(RenegadeClientError::relayer(body))
-        }
     }
 
     // --------------

--- a/src/renegade_wallet_client/config.rs
+++ b/src/renegade_wallet_client/config.rs
@@ -9,10 +9,26 @@ use alloy::{
     signers::local::PrivateKeySigner,
 };
 
-use crate::{
-    ARBITRUM_ONE_RELAYER_BASE_URL, ARBITRUM_SEPOLIA_RELAYER_BASE_URL,
-    BASE_MAINNET_RELAYER_BASE_URL, BASE_SEPOLIA_RELAYER_BASE_URL,
-};
+// --- Relayer URLs --- //
+
+/// The Arbitrum Sepolia relayer base URL
+pub(crate) const ARBITRUM_SEPOLIA_RELAYER_BASE_URL: &str =
+    "https://arbitrum-sepolia.relayer.renegade.fi";
+/// The Arbitrum One relayer base URL
+pub(crate) const ARBITRUM_ONE_RELAYER_BASE_URL: &str = "https://arbitrum-one.relayer.renegade.fi";
+/// The Base Sepolia relayer base URL
+pub(crate) const BASE_SEPOLIA_RELAYER_BASE_URL: &str = "https://base-sepolia.relayer.renegade.fi";
+/// The Base mainnet relayer base URL
+pub(crate) const BASE_MAINNET_RELAYER_BASE_URL: &str = "https://base-mainnet.relayer.renegade.fi";
+
+// --- Historical State URLs --- //
+
+/// The mainnet historical state base URL
+pub(crate) const MAINNET_HISTORICAL_STATE_BASE_URL: &str =
+    "https://mainnet.historical-state.renegade.fi";
+/// The testnet historical state base URL
+pub(crate) const TESTNET_HISTORICAL_STATE_BASE_URL: &str =
+    "https://testnet.historical-state.renegade.fi";
 
 // --- Chain IDs --- //
 
@@ -60,6 +76,8 @@ pub(crate) const BASE_SEPOLIA_PERMIT2_ADDRESS: Address =
 pub struct RenegadeClientConfig {
     /// The relayer base URL
     pub relayer_base_url: String,
+    /// The historical state base URL
+    pub historical_state_base_url: String,
     /// The chain ID
     pub chain_id: u64,
     /// The darkpool contract address
@@ -75,6 +93,7 @@ impl RenegadeClientConfig {
     pub fn new_arbitrum_one(key: &PrivateKeySigner) -> Self {
         Self {
             relayer_base_url: ARBITRUM_ONE_RELAYER_BASE_URL.to_string(),
+            historical_state_base_url: MAINNET_HISTORICAL_STATE_BASE_URL.to_string(),
             chain_id: ARBITRUM_ONE_CHAIN_ID,
             darkpool_address: ARBITRUM_ONE_DARKPOOL_ADDRESS,
             permit2_address: ARBITRUM_ONE_PERMIT2_ADDRESS,
@@ -86,6 +105,7 @@ impl RenegadeClientConfig {
     pub fn new_arbitrum_sepolia(key: &PrivateKeySigner) -> Self {
         Self {
             relayer_base_url: ARBITRUM_SEPOLIA_RELAYER_BASE_URL.to_string(),
+            historical_state_base_url: TESTNET_HISTORICAL_STATE_BASE_URL.to_string(),
             chain_id: ARBITRUM_SEPOLIA_CHAIN_ID,
             darkpool_address: ARBITRUM_SEPOLIA_DARKPOOL_ADDRESS,
             permit2_address: ARBITRUM_SEPOLIA_PERMIT2_ADDRESS,
@@ -97,6 +117,7 @@ impl RenegadeClientConfig {
     pub fn new_base_mainnet(key: &PrivateKeySigner) -> Self {
         Self {
             relayer_base_url: BASE_MAINNET_RELAYER_BASE_URL.to_string(),
+            historical_state_base_url: MAINNET_HISTORICAL_STATE_BASE_URL.to_string(),
             chain_id: BASE_MAINNET_CHAIN_ID,
             darkpool_address: BASE_MAINNET_DARKPOOL_ADDRESS,
             permit2_address: BASE_MAINNET_PERMIT2_ADDRESS,
@@ -108,6 +129,7 @@ impl RenegadeClientConfig {
     pub fn new_base_sepolia(key: &PrivateKeySigner) -> Self {
         Self {
             relayer_base_url: BASE_SEPOLIA_RELAYER_BASE_URL.to_string(),
+            historical_state_base_url: TESTNET_HISTORICAL_STATE_BASE_URL.to_string(),
             chain_id: BASE_SEPOLIA_CHAIN_ID,
             darkpool_address: BASE_SEPOLIA_DARKPOOL_ADDRESS,
             permit2_address: BASE_SEPOLIA_PERMIT2_ADDRESS,

--- a/src/renegade_wallet_client/mod.rs
+++ b/src/renegade_wallet_client/mod.rs
@@ -1,5 +1,7 @@
 //! The renegade wallet client manages Renegade wallet operations
 
+use crate::http::RelayerHttpClientError;
+
 pub mod actions;
 pub mod client;
 pub mod config;
@@ -19,7 +21,7 @@ pub enum RenegadeClientError {
     InvalidOrder(String),
     /// A relayer error
     #[error("relayer error: {0}")]
-    Relayer(String),
+    Relayer(RelayerHttpClientError),
     /// An error sending a request to the relayer
     #[error("failed to send request to relayer: {0}")]
     Request(String),
@@ -77,12 +79,6 @@ impl RenegadeClientError {
         Self::Task(msg.to_string())
     }
 
-    /// Create a new relayer error
-    #[allow(clippy::needless_pass_by_value)]
-    pub fn relayer<T: ToString>(msg: T) -> Self {
-        Self::Relayer(msg.to_string())
-    }
-
     /// Create a new request error
     #[allow(clippy::needless_pass_by_value)]
     pub fn request<T: ToString>(msg: T) -> Self {
@@ -99,5 +95,11 @@ impl RenegadeClientError {
     #[allow(clippy::needless_pass_by_value)]
     pub fn websocket<T: ToString>(msg: T) -> Self {
         Self::Websocket(msg.to_string())
+    }
+}
+
+impl From<RelayerHttpClientError> for RenegadeClientError {
+    fn from(err: RelayerHttpClientError) -> Self {
+        Self::Relayer(err)
     }
 }

--- a/src/renegade_wallet_client/websocket/client.rs
+++ b/src/renegade_wallet_client/websocket/client.rs
@@ -109,7 +109,7 @@ impl RenegadeWebsocketClient {
         &self,
         task_id: TaskIdentifier,
     ) -> Result<TaskNotificationRx, RenegadeClientError> {
-        self.ensure_connected().await?;
+        self.ensure_connected().await;
         // Send a subscription message to the websocket client
         let subscribe_tx = self
             .subscribe_tx
@@ -129,18 +129,17 @@ impl RenegadeWebsocketClient {
     /// once if it is needed. The initialization spawns a thread to watch
     /// subscribed topics and forward them to threads watching for
     /// notifications.
-    pub async fn ensure_connected(&self) -> Result<(), RenegadeClientError> {
+    pub async fn ensure_connected(&self) {
         self.subscribe_tx
-            .get_or_try_init(|| async {
+            .get_or_init(|| async {
                 let (tx, rx) = create_subscription_channel();
                 let base_url = self.base_url.clone();
                 let notifications = self.notifications.clone();
                 tokio::spawn(Self::ws_reconnection_loop(base_url, rx, notifications));
 
-                Ok(tx)
+                tx
             })
-            .await?;
-        Ok(())
+            .await;
     }
 
     // ----------------------

--- a/src/renegade_wallet_client/websocket/client.rs
+++ b/src/renegade_wallet_client/websocket/client.rs
@@ -9,6 +9,7 @@ use renegade_api::{
     websocket::{ClientWebsocketMessage, WebsocketMessage},
 };
 use renegade_common::types::tasks::TaskIdentifier;
+use renegade_common::types::wallet::WalletIdentifier;
 use tokio::sync::{
     mpsc::{self, UnboundedReceiver, UnboundedSender},
     OnceCell, RwLock,
@@ -16,6 +17,8 @@ use tokio::sync::{
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{error, warn};
 
+use crate::actions::get_task_history::get_task_history;
+use crate::http::RelayerHttpClient;
 use crate::{
     renegade_wallet_client::config::RenegadeClientConfig,
     websocket::task_waiter::TaskStatusNotification, RenegadeClientError,
@@ -75,10 +78,15 @@ fn construct_websocket_topic(task_id: TaskIdentifier) -> String {
 // --------------------
 
 /// The websocket client for listening to Renegade events
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RenegadeWebsocketClient {
     /// The base url of the websocket server
     base_url: String,
+    /// The wallet ID
+    wallet_id: WalletIdentifier,
+    /// The historical state client, used to check task history in the case of
+    /// missed updates
+    historical_state_client: Arc<RelayerHttpClient>,
     /// The notifications map
     notifications: NotificationMap,
     /// The channel to subscribe to task status updates
@@ -89,12 +97,18 @@ pub struct RenegadeWebsocketClient {
 
 impl RenegadeWebsocketClient {
     /// Create a new websocket client
-    pub fn new(config: &RenegadeClientConfig) -> Self {
+    pub fn new(
+        config: &RenegadeClientConfig,
+        wallet_id: WalletIdentifier,
+        historical_state_client: Arc<RelayerHttpClient>,
+    ) -> Self {
         let base_url = config.relayer_base_url.replace("http", "ws");
         let base_url = format!("{base_url}:{DEFAULT_WS_PORT}");
 
         Self {
             base_url,
+            wallet_id,
+            historical_state_client,
             notifications: create_notification_map(),
             subscribe_tx: Arc::new(OnceCell::new()),
         }
@@ -133,9 +147,8 @@ impl RenegadeWebsocketClient {
         self.subscribe_tx
             .get_or_init(|| async {
                 let (tx, rx) = create_subscription_channel();
-                let base_url = self.base_url.clone();
-                let notifications = self.notifications.clone();
-                tokio::spawn(Self::ws_reconnection_loop(base_url, rx, notifications));
+                let self_clone = self.clone();
+                tokio::spawn(self_clone.ws_reconnection_loop(rx));
 
                 tx
             })
@@ -148,16 +161,9 @@ impl RenegadeWebsocketClient {
 
     /// Websocket reconnection loop. Re-establishes the websocket connection
     /// if there is an error in handling it.
-    async fn ws_reconnection_loop(
-        base_url: String,
-        mut subscribe_rx: SubscribeRx,
-        notifications: NotificationMap,
-    ) {
+    async fn ws_reconnection_loop(self, mut subscribe_rx: SubscribeRx) {
         loop {
-            if let Err(e) =
-                Self::handle_ws_connection(&base_url, &mut subscribe_rx, notifications.clone())
-                    .await
-            {
+            if let Err(e) = self.handle_ws_connection(&mut subscribe_rx).await {
                 error!("Error handling websocket connection: {e}");
             }
 
@@ -168,11 +174,10 @@ impl RenegadeWebsocketClient {
 
     /// Connection handler loop
     async fn handle_ws_connection(
-        base_url: &str,
+        &self,
         subscribe_rx: &mut SubscribeRx,
-        notifications: NotificationMap,
     ) -> Result<(), RenegadeClientError> {
-        let (ws_stream, _response) = connect_async(base_url).await.map_err(|e| {
+        let (ws_stream, _response) = connect_async(&self.base_url).await.map_err(|e| {
             RenegadeClientError::custom(format!("Failed to connect to websocket: {e}"))
         })?;
 
@@ -180,7 +185,7 @@ impl RenegadeWebsocketClient {
         let (mut ws_tx, mut ws_rx) = ws_stream.split();
 
         // Re-subscribe to all tasks in the notification map
-        Self::resubscribe_to_all_tasks(notifications.clone(), &mut ws_tx).await?;
+        self.resubscribe_to_all_tasks(&mut ws_tx).await?;
 
         loop {
             tokio::select! {
@@ -196,7 +201,7 @@ impl RenegadeWebsocketClient {
                     };
 
                     // Handle the incoming message
-                    if let Err(e) = Self::handle_incoming_message(txt, notifications.clone()).await {
+                    if let Err(e) = self.handle_incoming_message(txt).await {
                         error!("Failed to handle incoming websocket message: {e}");
                     }
                 }
@@ -209,10 +214,10 @@ impl RenegadeWebsocketClient {
 
     /// Resubscribe to all tasks in the notification map
     async fn resubscribe_to_all_tasks<W: Sink<Message> + Unpin>(
-        notifications: NotificationMap,
+        &self,
         ws_tx: &mut W,
     ) -> Result<(), RenegadeClientError> {
-        let notif_map = notifications.read().await;
+        let notif_map = self.notifications.read().await;
         let task_ids: Vec<TaskIdentifier> = notif_map.keys().cloned().collect();
         drop(notif_map);
 
@@ -242,18 +247,23 @@ impl RenegadeWebsocketClient {
     }
 
     /// Handle an incoming websocket message
-    async fn handle_incoming_message(
-        txt: String,
-        notifications: NotificationMap,
-    ) -> Result<(), RenegadeClientError> {
+    async fn handle_incoming_message(&self, txt: String) -> Result<(), RenegadeClientError> {
         let msg: ServerMessage =
             match serde_json::from_str(&txt).map_err(RenegadeClientError::serde) {
                 Ok(msg) => msg,
                 Err(e) => {
-                    // It's likely the message was a subscription response. If we find the relevant
-                    // "subscriptions" substring, we simply return early.
+                    // If the message contains the "subscriptions" substring, we interpret this as a
+                    // subscriptions response, and return early
                     if txt.contains("subscriptions") {
                         return Ok(());
+                    }
+
+                    // If the message contains the "task not found" substring, we interpret this as
+                    // a task having completed, so we check task history to track the
+                    // success/failure of all completed tasks
+                    if txt.contains("task not found") {
+                        warn!("Task not found in relayer, checking task history...");
+                        return self.handle_historic_tasks().await;
                     }
 
                     return Err(e);
@@ -266,9 +276,9 @@ impl RenegadeWebsocketClient {
                 let id = status.id;
                 let state = status.state.to_lowercase();
                 if state.contains("completed") {
-                    Self::handle_completed_task(id, notifications).await?;
+                    self.handle_completed_task(id).await?;
                 } else if state.contains("failed") {
-                    Self::handle_failed_task(id, state, notifications).await?;
+                    self.handle_failed_task(id, state).await?;
                 }
             },
             _ => return Ok(()),
@@ -278,10 +288,10 @@ impl RenegadeWebsocketClient {
 
     /// Handle a completed task
     async fn handle_completed_task(
+        &self,
         task_id: TaskIdentifier,
-        notifications: NotificationMap,
     ) -> Result<(), RenegadeClientError> {
-        let mut notif_map = notifications.write().await;
+        let mut notif_map = self.notifications.write().await;
         let tx = match notif_map.remove(&task_id) {
             Some(tx) => tx.clone(),
             None => return Ok(()),
@@ -294,11 +304,11 @@ impl RenegadeWebsocketClient {
 
     /// Handle a failed task
     async fn handle_failed_task(
+        &self,
         task_id: TaskIdentifier,
         error: String,
-        notifications: NotificationMap,
     ) -> Result<(), RenegadeClientError> {
-        let mut notif_map = notifications.write().await;
+        let mut notif_map = self.notifications.write().await;
         let tx = match notif_map.remove(&task_id) {
             Some(tx) => tx.clone(),
             None => return Ok(()),
@@ -306,6 +316,29 @@ impl RenegadeWebsocketClient {
 
         // We explicitly ignore errors here in case the receiver is dropped
         let _ = tx.send(TaskStatusNotification::Failed { error });
+        Ok(())
+    }
+
+    /// Handle historic tasks that may have been missed by the websocket client
+    async fn handle_historic_tasks(&self) -> Result<(), RenegadeClientError> {
+        let task_history = get_task_history(&self.historical_state_client, self.wallet_id).await?;
+
+        let notif_map = self.notifications.read().await;
+        let task_ids: Vec<TaskIdentifier> = notif_map.keys().cloned().collect();
+        drop(notif_map);
+
+        for task_id in task_ids {
+            let task = task_history.iter().find(|task| task.id == task_id);
+            if let Some(task) = task {
+                let state = task.state.to_lowercase();
+                if state.contains("completed") {
+                    self.handle_completed_task(task_id).await?;
+                } else if state.contains("failed") {
+                    self.handle_failed_task(task_id, state).await?;
+                }
+            }
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
In this PR, we add a new action for fetching the client wallet's task history from the historical state engine. We rely on this action as a fallback in the `TaskWaiter`: if we receive a "task not found" websocket message, indicating that we attempted to subscribe to an already-completed task (likely due to websocket closure + resubscription), we attempt to find the task in task history and handle its final status accordingly.

### Testing
- [x] Test `get_task_history` action
- [x] Test task history fallback in `TaskWaiter` via mocked failure on first subscription attempt