### PR TITLE
renegade_wallet_client: use chain-specific base URL for HSE

### DIFF
--- a/src/renegade_wallet_client/client.rs
+++ b/src/renegade_wallet_client/client.rs
@@ -15,6 +15,7 @@ use renegade_common::types::wallet::{
 use renegade_constants::Scalar;
 use uuid::Uuid;
 
+use crate::util::get_env_agnostic_chain;
 use crate::websocket::TaskWaiter;
 use crate::{
     http::RelayerHttpClient,
@@ -87,8 +88,9 @@ impl RenegadeClient {
         let relayer_client =
             RelayerHttpClient::new(config.relayer_base_url.clone(), HttpHmacKey(hmac_key.0));
 
+        let chain = get_env_agnostic_chain(config.chain_id);
         let historical_state_client = Arc::new(RelayerHttpClient::new(
-            config.historical_state_base_url.clone(),
+            format!("{}/{chain}", config.historical_state_base_url),
             HttpHmacKey(hmac_key.0),
         ));
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,13 @@ use base64::engine::{general_purpose as b64_general_purpose, Engine};
 use hmac::Mac;
 use reqwest::header::{HeaderMap, HeaderValue};
 
-use crate::ExternalMatchClientError;
+use crate::{
+    config::{
+        ARBITRUM_ONE_CHAIN_ID, ARBITRUM_SEPOLIA_CHAIN_ID, BASE_MAINNET_CHAIN_ID,
+        BASE_SEPOLIA_CHAIN_ID,
+    },
+    ExternalMatchClientError,
+};
 
 /// The header namespace to include in the HMAC
 const RENEGADE_HEADER_NAMESPACE: &str = "x-renegade";
@@ -100,4 +106,13 @@ fn get_header_bytes(headers: &HeaderMap) -> Vec<u8> {
 /// Returns the current unix timestamp in milliseconds, represented as u64
 pub fn get_current_time_millis() -> u64 {
     SystemTime::now().duration_since(UNIX_EPOCH).expect("negative timestamp").as_millis() as u64
+}
+
+/// Returns the environment-agnostic name of the chain with the given ID
+pub fn get_env_agnostic_chain(chain_id: u64) -> String {
+    match chain_id {
+        ARBITRUM_ONE_CHAIN_ID | ARBITRUM_SEPOLIA_CHAIN_ID => "arbitrum".to_string(),
+        BASE_MAINNET_CHAIN_ID | BASE_SEPOLIA_CHAIN_ID => "base".to_string(),
+        _ => panic!("Unsupported chain ID: {chain_id}"),
+    }
 }


### PR DESCRIPTION
In this PR, we update the initialization of the `RelayerHttpClient` for the historical state engine to use a chain-specific base URL.

### Testing
- [x] Test fetching chain-specific task history against update historical state engine