### PR TITLE
Inline auth deps to remove nightly requirement from external-match-client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renegade-sdk"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 description = "A Rust SDK for the Renegade protocol"
 homepage = "https://renegade.fi/"
@@ -138,13 +138,16 @@ required-features = ["examples", "darkpool-client"]
 default = ["external-match-client", "darkpool-client"]
 external-match-client = []
 darkpool-client = [
+    "dep:ark-ff",
     "dep:futures-util",
     "dep:rand",
     "dep:renegade-circuit-types",
     "dep:renegade-darkpool-types",
     "dep:renegade-constants",
     "dep:renegade-crypto",
+    "dep:renegade-external-api",
     "dep:renegade-solidity-abi",
+    "dep:renegade-types-core",
     "dep:tokio",
     "dep:tokio-stream",
     "dep:tokio-tungstenite",
@@ -156,6 +159,7 @@ internal = []
 
 [dependencies]
 # === Auth === #
+hex = "0.4"
 hmac = "0.12"
 sha2 = { version = "0.10", features = ["asm"] }
 
@@ -177,10 +181,10 @@ alloy-rpc-types-eth = { version = ">=0.12, <2.0" }
 k256 = { version = "0.13", features = ["ecdsa"] }
 
 # === Renegade Dependencies === #
-renegade-types-core = { package = "types-core", git = "https://github.com/renegade-fi/renegade.git", features = [
+renegade-types-core = { package = "types-core", git = "https://github.com/renegade-fi/renegade.git", optional = true, features = [
     "hmac",
 ] }
-renegade-external-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", default-features = false, features = [
+renegade-external-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", optional = true, default-features = false, features = [
     "auth", "external-match-api"
 ] }
 renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git", optional = true, features = [
@@ -199,7 +203,7 @@ renegade-solidity-abi = { package = "abi", git = "https://github.com/renegade-fi
 ], optional = true }
 
 # === Cryptography === #
-ark-ff = "0.4"
+ark-ff = { version = "0.4", optional = true }
 rand = { version = "0.8", optional = true }
 
 # === Misc === #

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,201 @@
+//! Types and utilities for HMAC-based authentication
+//!
+//! Inlines `HmacKey` (from `types-core`) and `add_expiring_auth_to_headers`
+//! (from `external-api`) so the `external-match-client` feature path does not
+//! pull in the full renegade dependency tree.
+
+use base64::engine::{Engine, general_purpose as b64_general_purpose};
+use hmac::Mac;
+use reqwest::header::{HeaderMap, HeaderValue};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+// -------------
+// | Constants |
+// -------------
+
+/// The length of an HMAC key in bytes
+pub const HMAC_KEY_LEN: usize = 32;
+
+/// The header name for the renegade auth signature
+const RENEGADE_AUTH_HEADER_NAME: &str = "x-renegade-auth";
+
+/// The header name for the renegade auth signature expiration
+const RENEGADE_SIG_EXPIRATION_HEADER_NAME: &str = "x-renegade-auth-expiration";
+
+/// The header namespace to include in the HMAC
+const RENEGADE_HEADER_NAMESPACE: &str = "x-renegade";
+
+// ---------
+// | Types |
+// ---------
+
+/// Type alias for the hmac core implementation
+type HmacSha256 = hmac::Hmac<Sha256>;
+
+/// A type representing a symmetric HMAC key
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HmacKey(pub [u8; HMAC_KEY_LEN]);
+
+#[cfg(feature = "darkpool-client")]
+impl From<HmacKey> for renegade_types_core::HmacKey {
+    fn from(key: HmacKey) -> Self {
+        Self(key.0)
+    }
+}
+
+#[cfg(feature = "darkpool-client")]
+impl From<renegade_types_core::HmacKey> for HmacKey {
+    fn from(key: renegade_types_core::HmacKey) -> Self {
+        Self(key.0)
+    }
+}
+
+impl HmacKey {
+    /// Create a new HMAC key from a hex string
+    pub fn new(hex: &str) -> Result<Self, String> {
+        Self::from_hex_string(hex)
+    }
+
+    /// Get the inner bytes
+    pub fn inner(&self) -> &[u8; HMAC_KEY_LEN] {
+        &self.0
+    }
+
+    /// Create a new random HMAC key
+    #[cfg(feature = "darkpool-client")]
+    pub fn random() -> Self {
+        use rand::RngCore;
+        let mut rng = rand::thread_rng();
+        let mut bytes = [0; HMAC_KEY_LEN];
+        rng.fill_bytes(&mut bytes);
+        Self(bytes)
+    }
+
+    /// Convert the HMAC key to a hex string
+    pub fn to_hex_string(&self) -> String {
+        format!("0x{}", hex::encode(self.0))
+    }
+
+    /// Try to convert a hex string to an HMAC key
+    pub fn from_hex_string(hex_str: &str) -> Result<Self, String> {
+        let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+        let bytes = hex::decode(hex_str)
+            .map_err(|e| format!("error deserializing bytes from hex string: {e}"))?;
+
+        if bytes.len() != HMAC_KEY_LEN {
+            return Err(format!("expected {HMAC_KEY_LEN} byte HMAC key, got {}", bytes.len()));
+        }
+
+        Ok(Self(bytes.try_into().unwrap()))
+    }
+
+    /// Convert the HMAC key to a base64 string
+    pub fn to_base64_string(&self) -> String {
+        b64_general_purpose::STANDARD.encode(self.0)
+    }
+
+    /// Try to convert a base64 string to an HMAC key
+    pub fn from_base64_string(base64: &str) -> Result<Self, String> {
+        let bytes = b64_general_purpose::STANDARD.decode(base64).map_err(|e| e.to_string())?;
+        if bytes.len() != HMAC_KEY_LEN {
+            return Err(format!("expected {HMAC_KEY_LEN} byte HMAC key, got {}", bytes.len()));
+        }
+
+        Ok(Self(bytes.try_into().unwrap()))
+    }
+
+    /// Try to create an HMAC key from a byte slice
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
+        if bytes.len() != HMAC_KEY_LEN {
+            return Err(format!("expected {HMAC_KEY_LEN} byte HMAC key, got {}", bytes.len()));
+        }
+
+        Ok(Self(bytes.try_into().unwrap()))
+    }
+
+    /// Compute the HMAC of a message
+    pub fn compute_mac(&self, msg: &[u8]) -> Vec<u8> {
+        let mut hmac =
+            HmacSha256::new_from_slice(self.inner()).expect("hmac can handle all slice lengths");
+        hmac.update(msg);
+        hmac.finalize().into_bytes().to_vec()
+    }
+
+    /// Verify the HMAC of a message
+    pub fn verify_mac(&self, msg: &[u8], mac: &[u8]) -> bool {
+        self.compute_mac(msg) == mac
+    }
+}
+
+// --------------------
+// | Public Interface |
+// --------------------
+
+/// Add an auth expiration and signature to a set of headers
+pub fn add_expiring_auth_to_headers(
+    path: &str,
+    headers: &mut HeaderMap,
+    body: &[u8],
+    key: &HmacKey,
+    expiration: Duration,
+) {
+    // Add a timestamp
+    let now_millis =
+        SystemTime::now().duration_since(UNIX_EPOCH).expect("negative timestamp").as_millis()
+            as u64;
+    let expiration_ts = now_millis + expiration.as_millis() as u64;
+    headers.insert(RENEGADE_SIG_EXPIRATION_HEADER_NAME, expiration_ts.into());
+
+    // Add the signature
+    let sig = create_request_signature(path, headers, body, key);
+    let b64_sig = b64_general_purpose::STANDARD_NO_PAD.encode(sig);
+    let sig_header = HeaderValue::from_str(&b64_sig).expect("b64 encoding should not fail");
+    headers.insert(RENEGADE_AUTH_HEADER_NAME, sig_header);
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Create a request signature
+fn create_request_signature(
+    path: &str,
+    headers: &HeaderMap,
+    body: &[u8],
+    key: &HmacKey,
+) -> Vec<u8> {
+    let path_bytes = path.as_bytes();
+    let header_bytes = get_header_bytes(headers);
+    let payload = [path_bytes, &header_bytes, body].concat();
+
+    key.compute_mac(&payload)
+}
+
+/// Get the header bytes to include in an HMAC
+fn get_header_bytes(headers: &HeaderMap) -> Vec<u8> {
+    let mut headers_buf = Vec::new();
+
+    // Filter out non-Renegade headers and the auth header
+    let mut renegade_headers = headers
+        .iter()
+        .filter_map(|(k, v)| {
+            let key = k.to_string().to_lowercase();
+            if key.starts_with(RENEGADE_HEADER_NAMESPACE) && key != RENEGADE_AUTH_HEADER_NAME {
+                Some((key, v))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // Sort alphabetically, then add to the buffer
+    renegade_headers.sort_by(|a, b| a.0.cmp(&b.0));
+    for (key, value) in renegade_headers {
+        headers_buf.extend_from_slice(key.as_bytes());
+        headers_buf.extend_from_slice(value.as_bytes());
+    }
+
+    headers_buf
+}

--- a/src/external_match_client/client.rs
+++ b/src/external_match_client/client.rs
@@ -1,6 +1,6 @@
 //! The client for requesting external matches
 
-use renegade_types_core::HmacKey;
+use crate::auth::HmacKey;
 use reqwest::{
     StatusCode,
     header::{HeaderMap, HeaderValue},

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,7 +1,6 @@
 //! HTTP client for connecting to the relayer
 
-use renegade_external_api::auth::add_expiring_auth_to_headers;
-use renegade_types_core::HmacKey;
+use crate::auth::{HmacKey, add_expiring_auth_to_headers};
 use reqwest::{Client, header::HeaderMap};
 use serde::{Serialize, de::DeserializeOwned};
 use std::time::Duration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,14 @@
 #![deny(unsafe_code)]
 #![deny(clippy::needless_pass_by_ref_mut)]
 
+pub mod auth;
 #[cfg(feature = "external-match-client")]
 pub(crate) mod external_match_client;
 mod http;
 pub mod types;
 mod util;
+
+pub use auth::HmacKey;
 
 #[cfg(feature = "internal")]
 pub use http::*;

--- a/src/renegade_wallet_client/actions/create_account.rs
+++ b/src/renegade_wallet_client/actions/create_account.rs
@@ -24,7 +24,7 @@ impl RenegadeClient {
             account_id,
             address,
             master_view_seed,
-            auth_hmac_key,
+            auth_hmac_key: auth_hmac_key.into(),
             schnorr_public_key,
         };
 

--- a/src/renegade_wallet_client/actions/sync_account.rs
+++ b/src/renegade_wallet_client/actions/sync_account.rs
@@ -47,7 +47,7 @@ impl RenegadeClient {
         SyncAccountRequest {
             account_id: self.get_account_id(),
             master_view_seed: self.get_master_view_seed(),
-            auth_hmac_key: self.get_auth_hmac_key(),
+            auth_hmac_key: self.get_auth_hmac_key().into(),
             schnorr_public_key: self.get_schnorr_public_key(),
         }
     }

--- a/src/renegade_wallet_client/client.rs
+++ b/src/renegade_wallet_client/client.rs
@@ -3,13 +3,13 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::auth::HmacKey;
 use alloy::primitives::Address;
 use alloy::signers::local::PrivateKeySigner;
 use futures_util::Stream;
 use renegade_circuit_types::schnorr::{SchnorrPrivateKey, SchnorrPublicKey, SchnorrSignature};
 use renegade_circuit_types::traits::BaseType;
 use renegade_constants::Scalar;
-use renegade_types_core::HmacKey;
 use uuid::Uuid;
 
 use renegade_external_api::types::websocket::{

--- a/src/renegade_wallet_client/config.rs
+++ b/src/renegade_wallet_client/config.rs
@@ -4,11 +4,11 @@
 // | Constants |
 // -------------
 
+use crate::auth::HmacKey;
 use alloy::{
     primitives::{Address, address},
     signers::local::PrivateKeySigner,
 };
-use renegade_types_core::HmacKey;
 
 use crate::{
     ARBITRUM_ONE_CHAIN_ID, ARBITRUM_ONE_RELAYER_BASE_URL, ARBITRUM_SEPOLIA_CHAIN_ID,

--- a/src/renegade_wallet_client/utils.rs
+++ b/src/renegade_wallet_client/utils.rs
@@ -1,10 +1,10 @@
 //! Shared utilities for the Renegade wallet client
 
+use crate::auth::HmacKey;
 use alloy::{primitives::keccak256, signers::SignerSync, signers::local::PrivateKeySigner, sol};
 use ark_ff::PrimeField;
 use renegade_circuit_types::schnorr::SchnorrPrivateKey;
 use renegade_constants::{EmbeddedScalarField, Scalar};
-use renegade_types_core::HmacKey;
 use uuid::Uuid;
 
 // -------------

--- a/src/renegade_wallet_client/websocket/client.rs
+++ b/src/renegade_wallet_client/websocket/client.rs
@@ -3,6 +3,7 @@
 use std::sync::{Arc, OnceLock};
 use std::{collections::HashMap, time::Duration};
 
+use crate::auth::HmacKey;
 use futures_util::Stream;
 use futures_util::stream::SplitSink;
 use renegade_external_api::types::websocket::ServerWebsocketMessageBody;
@@ -10,7 +11,6 @@ use renegade_external_api::types::{
     AdminBalanceUpdateMessage, AdminOrderUpdateMessage, BalanceUpdateMessage, FillMessage,
     OrderUpdateMessage, TaskUpdateMessage,
 };
-use renegade_types_core::HmacKey;
 use tokio::net::TcpStream;
 use tokio::sync::{
     OnceCell as AsyncOnceCell, RwLock,

--- a/src/renegade_wallet_client/websocket/subscriptions.rs
+++ b/src/renegade_wallet_client/websocket/subscriptions.rs
@@ -3,13 +3,13 @@
 
 use std::{collections::HashMap, time::Duration};
 
+use crate::auth::HmacKey;
+use crate::auth::add_expiring_auth_to_headers;
 use futures_util::{SinkExt, StreamExt};
-use renegade_external_api::auth::add_expiring_auth_to_headers;
 use renegade_external_api::types::websocket::{
     ClientWebsocketMessage, ClientWebsocketMessageBody, ServerWebsocketMessage,
     ServerWebsocketMessageBody,
 };
-use renegade_types_core::HmacKey;
 use reqwest::header::HeaderMap;
 use tokio::sync::{
     RwLock,


### PR DESCRIPTION
## Summary
- Inlines `HmacKey` and `add_expiring_auth_to_headers` into a new `src/auth.rs` module, removing the need for `renegade-types-core` and `renegade-external-api` in the `external-match-client` feature path
- Makes `renegade-types-core`, `renegade-external-api`, and `ark-ff` optional deps gated behind `darkpool-client`
- Users building with `--features external-match-client --no-default-features` no longer pull in `circuit-types` → `ark-mpc` and the full MPC/proof-system tree, eliminating the nightly Rust requirement

## Test plan
- [x] `cargo check --no-default-features --features external-match-client` compiles
- [x] `cargo tree --no-default-features --features external-match-client | grep ark-mpc` returns empty
- [x] `cargo check --no-default-features --features darkpool-client` compiles
- [x] `cargo check` (default features) compiles
- [x] `cargo clippy` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)