### PR TITLE
external-match-client: exact-output: Add parity examples and redundant-case shim

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,11 @@ path = "examples/external_match/in_kind_gas_sponsorship.rs"
 required-features = ["examples"]
 
 [[example]]
+name = "exact_base_output"
+path = "examples/external_match/exact_base_output.rs"
+required-features = ["examples"]
+
+[[example]]
 name = "exact_quote_output"
 path = "examples/external_match/exact_quote_output.rs"
 required-features = ["examples"]

--- a/examples/external_match/exact_base_output.rs
+++ b/examples/external_match/exact_base_output.rs
@@ -1,10 +1,10 @@
-//! Sell with exact quote output: receive exactly N quote tokens.
+//! Buy with exact base output: receive exactly N base tokens.
 //!
-//! "I'm selling wETH and want to receive exactly this much USDC."
+//! "I'm buying wETH and want to receive exactly this many."
 
 use renegade_sdk::example_utils::{Wallet, build_renegade_client, execute_bundle, get_signer};
 use renegade_sdk::{
-    ExternalMatchClient, ExternalOrderBuilder, RequestQuoteOptions,
+    ExternalMatchClient, ExternalOrderBuilder,
     types::{ExternalOrder, OrderSide},
 };
 
@@ -21,13 +21,13 @@ async fn main() -> Result<(), eyre::Error> {
     let order = ExternalOrderBuilder::new()
         .base_mint(BASE_MINT)
         .quote_mint(QUOTE_MINT)
-        .exact_quote_output(30_000_000) // 30 USDC (6 decimals)
-        .side(OrderSide::Sell)
+        .exact_base_output(10_000_000_000_000_000) // 0.01 wETH (18 decimals)
+        .side(OrderSide::Buy)
         .build()
         .unwrap();
 
-    println!("=== Sell + exact_quote_output (exact receive) ===");
-    println!("Goal: receive exactly 30 USDC, sell whatever wETH is needed");
+    println!("=== Buy + exact_base_output (exact receive) ===");
+    println!("Goal: receive exactly 0.01 wETH, pay whatever USDC is needed");
     fetch_quote_and_execute(&client, order, &signer).await
 }
 
@@ -37,10 +37,7 @@ async fn fetch_quote_and_execute(
     wallet: &Wallet,
 ) -> Result<(), eyre::Error> {
     println!("Fetching quote...");
-    let quote = client
-        .request_quote_with_options(order, RequestQuoteOptions::default())
-        .await?
-        .ok_or_else(|| eyre::eyre!("No quote found"))?;
+    let quote = client.request_quote(order).await?.ok_or_else(|| eyre::eyre!("No quote found"))?;
 
     println!("Assembling quote...");
     let resp = client.assemble_quote(quote).await?.ok_or_else(|| eyre::eyre!("No bundle found"))?;

--- a/src/external_match_client/v1_conversions.rs
+++ b/src/external_match_client/v1_conversions.rs
@@ -44,7 +44,8 @@ pub(crate) fn v1_order_to_v2(order: &ExternalOrder) -> ExternalOrderV2 {
             } else if order.exact_base_output != 0 {
                 (0, order.exact_base_output, true)
             } else {
-                (order.exact_quote_output, 0, true)
+                // v1 alias: exact_quote_output on Buy is input-side exact spend
+                (order.exact_quote_output, 0, false)
             };
 
             ExternalOrderV2 {
@@ -65,7 +66,8 @@ pub(crate) fn v1_order_to_v2(order: &ExternalOrder) -> ExternalOrderV2 {
             } else if order.exact_quote_output != 0 {
                 (0, order.exact_quote_output, true)
             } else {
-                (order.exact_base_output, 0, true)
+                // v1 alias: exact_base_output on Sell is input-side exact spend
+                (order.exact_base_output, 0, false)
             };
 
             ExternalOrderV2 {


### PR DESCRIPTION
### Purpose
This PR adds external-match exact-output parity coverage in the Rust SDK and aligns redundant parameter combinations with v1 behavior.

It adds dedicated exact-output examples, keeps fixed-point match result price available in client API types/conversions for stable downstream handling, and introduces a redundant-case shim so equivalent user intents behave consistently.

### Testing
- [x] `source .env.local && cargo run --features examples --example exact_base_output`
- [x] `source .env.local && cargo run --features examples --example exact_quote_output`
- [x] Testnet tx (exact_base_output): `0x714daa6c8d68fafe767eae50459f812d2ab71eadad81275dd749bf2bcf19964a`
- [x] Testnet tx (exact_quote_output): `0xe982392e194a11df93268fd9476fc7aa9d31599f3d49b495029c82e44d957453`
