### PR TITLE
fix: route get_markets through auth server with API key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renegade-sdk"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2024"
 description = "A Rust SDK for the Renegade protocol"
 homepage = "https://renegade.fi/"

--- a/src/external_match_client/client.rs
+++ b/src/external_match_client/client.rs
@@ -207,7 +207,8 @@ impl ExternalMatchClient {
     /// and fee rates for each market.
     pub async fn get_markets(&self) -> Result<GetMarketsResponse, ExternalMatchClientError> {
         let path = GET_MARKETS_ROUTE;
-        let resp = self.relayer_http_client.get(path).await?;
+        let headers = self.get_headers()?;
+        let resp = self.auth_http_client.get_with_headers(path, headers).await?;
 
         Ok(resp)
     }


### PR DESCRIPTION
## Summary
- Fixes `get_markets()` to use `auth_http_client` with the `X-Renegade-Api-Key` header, matching the pattern used by `get_market_depth` and `get_market_depths_all_pairs`
- Previously used `relayer_http_client.get()` which bypassed the auth server and omitted the API key header, causing 401 errors

## Test plan
- [x] Tested locally against auth server — `get_markets()` returns all 18 markets with correct fee rates

🤖 Generated with [Claude Code](https://claude.com/claude-code)