### PR TITLE
feat: implement admin_assign_order_to_pool SDK method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Cargo.lock
 **/.DS_Store
 
 CLAUDE*.md
+.cargo/

--- a/src/renegade_wallet_client/actions/admin_assign_order_to_pool.rs
+++ b/src/renegade_wallet_client/actions/admin_assign_order_to_pool.rs
@@ -1,8 +1,12 @@
 //! Admin action to assign an order to a matching pool
 
+use renegade_external_api::{
+    EmptyRequestResponse,
+    http::admin::{ADMIN_ASSIGN_ORDER_TO_POOL_ROUTE, AssignOrderToPoolRequest},
+};
 use uuid::Uuid;
 
-use crate::{RenegadeClientError, client::RenegadeClient};
+use crate::{RenegadeClientError, actions::construct_http_path, client::RenegadeClient};
 
 impl RenegadeClient {
     /// Assigns an order to a specific matching pool via the admin API.
@@ -11,9 +15,17 @@ impl RenegadeClient {
     /// an admin HMAC key.
     pub async fn admin_assign_order_to_pool(
         &self,
-        _order_id: Uuid,
-        _matching_pool: String,
+        order_id: Uuid,
+        matching_pool: String,
     ) -> Result<(), RenegadeClientError> {
-        unimplemented!("admin_assign_order_to_pool is not supported in v2")
+        let admin_client = self.get_admin_client()?;
+
+        let path =
+            construct_http_path!(ADMIN_ASSIGN_ORDER_TO_POOL_ROUTE, "order_id" => order_id);
+
+        let body = AssignOrderToPoolRequest { matching_pool };
+        admin_client.post::<_, EmptyRequestResponse>(&path, body).await?;
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Replaces the `unimplemented!()` stub in `admin_assign_order_to_pool` with a working implementation that POSTs to the new `/v2/relayer-admin/orders/:order_id/assign-pool` endpoint.

Depends on renegade-fi/renegade#1421 for the new endpoint and `AssignOrderToPoolRequest` type.